### PR TITLE
Fix static arguments in function calls

### DIFF
--- a/m2isar/backends/etiss/instruction_transform.py
+++ b/m2isar/backends/etiss/instruction_transform.py
@@ -231,7 +231,6 @@ def function_call(self: behav.FunctionCall, context: TransformerContext):
 		name = self.ref_or_name[len("fdispatch_"):]
 		arg_str = ', '.join([context.make_static(arg.code) if arg.static else arg.code for arg in fn_args])
 
-
 		c = CodeString(f'{name}({arg_str})', StaticType.NONE, 64, False, mem_access, regs_affected)
 		return c
 

--- a/m2isar/backends/etiss/instruction_transform.py
+++ b/m2isar/backends/etiss/instruction_transform.py
@@ -87,7 +87,7 @@ def procedure_call(self: behav.ProcedureCall, context: TransformerContext):
 				arg.code = context.make_static(arg.code)
 
 		name = self.ref_or_name[len("dispatch_"):]
-		arg_str = ', '.join([arg.code for arg in fn_args])
+		arg_str = ', '.join([context.make_static(arg.code) if arg.static else arg.code for arg in fn_args])
 
 		mem_access = True in [arg.is_mem_access for arg in fn_args]
 		mem_ids = list(chain.from_iterable([arg.mem_ids for arg in fn_args]))
@@ -229,7 +229,8 @@ def function_call(self: behav.FunctionCall, context: TransformerContext):
 		mem_access = True in [arg.is_mem_access for arg in fn_args]
 		regs_affected = set(chain.from_iterable([arg.regs_affected for arg in fn_args]))
 		name = self.ref_or_name[len("fdispatch_"):]
-		arg_str = ', '.join([arg.code for arg in fn_args])
+		arg_str = ', '.join([context.make_static(arg.code) if arg.static else arg.code for arg in fn_args])
+
 
 		c = CodeString(f'{name}({arg_str})', StaticType.NONE, 64, False, mem_access, regs_affected)
 		return c

--- a/m2isar/frontends/coredsl/coredsl.lark
+++ b/m2isar/frontends/coredsl/coredsl.lark
@@ -60,7 +60,7 @@ operation: statement+
 
 return_: "return" expression ";"
 
-?assignment: (indexed_reference | | named_reference | scalar_definition) "<=" expression ";"
+?assignment: (indexed_reference | named_reference | scalar_definition) "<=" expression ";"
 
 bit_size_spec: "{" (natural | ID) "}"
 


### PR DESCRIPTION
Static arguments in function calls will now be correctly handled.

This behaviour code for example:
```
val _vtype[XLEN] <= CSR[VTYPE_ADDR];
val _vstart[XLEN] <= CSR[VSTART_ADDR];
val _vl[XLEN] <= CSR[VL_ADDR];
val _vlen[XLEN] <= CSR[VLENB_ADDR]*8;

val ret[XLEN] <= fdispatch_vadd_vv(V, _vtype, vm, vd, vs1, vs2, _vstart, _vlen, _vl);
```

would have been converted to this code:
```
...
partInit.code() += "etiss_uint32 ret = vadd_vv(((RISCV*)cpu)->V, _vtype, vm, vd, vs1, vs2, _vstart, _vlen, _vl);\n";
```

which would have caused an Error, as `vm`, `vd` and so on are not defined in the code that gets handed to the JIT. 
This statement now gets converted to:
```
...
partInit.code() += "etiss_uint32 ret = vadd_vv(((RISCV*)cpu)->V, _vtype, " + std::to_string(vm) + ", " + std::to_string(vd) + ", " + std::to_string(vs1) + ", " + std::to_string(vs2) + ", _vstart, _vlen, _vl);\n";
```
