### PR TITLE
coredsl2 parser: fix scoping issue

### DIFF
--- a/m2isar/frontends/coredsl2/parser.py
+++ b/m2isar/frontends/coredsl2/parser.py
@@ -169,6 +169,7 @@ def main():
 
 		always_block_statements = []
 
+		arch_builder = temp_save[core_name][1]
 		for block_def in arch_builder._always_blocks.values():
 			logger.debug("generating always block %s", block_def.name)
 			logger.debug("generating attributes")


### PR DESCRIPTION
Without this, all implemented cores would implement the always blocks contained in the last processed core instead of their individual ones.