### PR TITLE
etiss_instruction.mako: fix support for 48-bit instrs

### DIFF
--- a/m2isar/backends/etiss/templates/etiss_instruction.mako
+++ b/m2isar/backends/etiss/templates/etiss_instruction.mako
@@ -11,8 +11,8 @@ ${f'{"// "+instr_name+" ":-<80}'}
 static InstructionDefinition ${instr_name.lower().replace('.', '_')}_${'_'.join(seen_fields)} (
 	ISA${enc_idx}_${core_name},
 	"${instr_name.lower()}",
-	(uint${enc_idx}_t) ${code_string},
-	(uint${enc_idx}_t) ${mask_string},
+	(uint64_t) ${code_string},
+	(uint64_t) ${mask_string},
 ${callback_code},
 	0,
 	[] (BitArray & ba, Instruction & instr)


### PR DESCRIPTION
There is no `uint48_t` type in etiss since 48 is not a power of two. I think we should just default to `uint64_t` as I see no benefit in generating `uint16_t` and `uint32_t` depending on the enc_width.

@JoGei Any Comments?