### PR TITLE
Fix handling of non Pow2 assignments in ETISS writer & Optimize slices

### DIFF
--- a/.github/workflows/pr_trigger.yml
+++ b/.github/workflows/pr_trigger.yml
@@ -17,32 +17,127 @@
 ## limitations under the License.
 ##
 
-name: Trigger Seal5 ETISS Test Flow
+name: Trigger ETISS Test Flow and wait for completion
 
 on:
-  push:
-    pull_request: [ "coredsl2" ]
+  pull_request:
+    branches: [ "coredsl2" ]
+    paths:
+      - m2isar/frontends/coredsl2/**
+      - m2isar/metamodel/**
+      - m2isar/backends/etiss/**
+      - .github/workflows/**
 
 jobs:
   trigger_repo:
     runs-on: ubuntu-latest
     steps:
-    # - name: Trigger Seal5 ETISS Test Flow
-    #   uses: peter-evans/repository-dispatch@v3
-    #   with:
-    #      token: ${{ secrets.SEAL5_ACCESS_TOKEN }}
-    #      repository: tum-ei-eda/seal5_etiss_test_env
-    #      event-type: m2isar-event
-    #      client-payload: '{"triggered_run_id": "${{ github.run_id }}", "ref": "${{ github.sha }}", "from": "m2isar"}'
-    - uses: convictional/trigger-workflow-and-wait@v1.6.1
+    - name: Trigger Seal5 ETISS Test Flow
+      uses: peter-evans/repository-dispatch@v3
       with:
-        owner: tum-ei-eda
-        repo: seal5_etiss_test_env
-        github_token: ${{ secrets.SEAL5_ACCESS_TOKEN }}
-        ref: ${{ github.sha }}
-        wait_interval: 10
-        client_payload: '{"triggered_run_id": "${{ github.run_id }}", "ref": "${{ github.sha }}", "from": "m2isar"}'
-        propagate_failure: false
-        trigger_workflow: true
-        wait_workflow: true
-        comment_downstream_url: ${{ github.event.pull_request.comments_url }}
+         token: ${{ secrets.SEAL5_ACCESS_TOKEN }}
+         repository: tum-ei-eda/seal5_etiss_test_env
+         event-type: m2isar-event
+         client-payload: '{"triggered_run_id": "${{ github.run_id }}", "ref": "${{ github.event.pull_request.head.sha }}", "from": "m2isar", "is_pr": "true"}'
+    - name: Wait for Workflow Completion
+      run: |
+        echo "const https = require('https');
+        const MAX_ATTEMPTS = 8;
+        let attempt = 0;
+        const current_time = new Date();
+        console.log('Current Time: ', current_time.toISOString());
+        const tenSecsEarlier = new Date(current_time.getTime() - 10000);
+        const thirtySecsLater = new Date(current_time.getTime() + 30000);
+        async function checkWorkflowStatus() {
+          const options = {
+            hostname: 'api.github.com',
+            path: '/repos/tum-ei-eda/seal5_etiss_test_env/actions/runs',
+            method: 'GET',
+            headers: {
+              'Authorization': 'Bearer ${{ secrets.SEAL5_ACCESS_TOKEN }}',
+              'Accept': 'application/vnd.github.v3+json',
+              'User-Agent': 'Node.js Script'
+            }
+          };
+          // console.log('Options:', options);
+          return new Promise((resolve, reject) => {
+            https.get(options, (res) => {
+              let data = '';
+              res.on('data', (chunk) => {
+                data += chunk;
+              });
+              res.on('end', () => {
+                const response = JSON.parse(data);
+                if (!response.workflow_runs) {
+                  console.error('Unexpected response structure:', response);
+                  reject('Invalid API response');
+                  return;
+                }
+                // console.log('Responses:', response.workflow_runs);
+                // console.log('Response:', response.workflow_runs[0].status);
+                const workflowRuns = response.workflow_runs.filter(run =>
+                  new Date(run.created_at) > new Date(tenSecsEarlier) &&
+                  new Date(run.created_at) < new Date(thirtySecsLater) &&
+                  run.event === 'repository_dispatch' &&
+                  run.display_title === 'm2isar-event' &&
+                  run.path === '.github/workflows/default.yml'
+                );
+                // console.log('workflowRuns:', workflowRuns);
+                if (workflowRuns.length > 0) {
+                  const status = workflowRuns[0].status;
+                  const url = workflowRuns[0].html_url;
+                  const conclusion = workflowRuns[0].conclusion;
+                  console.log('URL of the matching workflow run: ', url);
+                  console.log('Status of the matching workflow run: ', status);
+                  // Check if the workflow run is completed
+                  if (status === 'completed') {
+                      console.log('Completed matching workflow run: ', status, conclusion);
+                      resolve({ status, conclusion });  // Resolving both status and conclusion
+                  } else {
+                      console.log('Workflow run is not completed yet');
+                      resolve({ status, conclusion: null }); // Conclusion is null if not completed
+                  }
+              } else {
+                  console.log('No workflow runs found');
+                  reject('No workflow runs found');  // Reject if no workflow runs are found
+              }
+              });
+            }).on('error', (e) => {
+              console.error(e);
+              reject(e);
+            });
+          });
+        }
+        async function waitForWorkflowCompletion() {
+          let res = {};
+          while (attempt < MAX_ATTEMPTS) {
+             try {
+                res = await checkWorkflowStatus();
+              } catch (error) {
+                console.error('Error checking workflow status:', error);
+              }
+              // ... handle status and conclusion ...
+            if (res && res.status === 'completed' && res.conclusion === 'success') {
+              console.log('Workflow completed and test passed!');
+              break
+            } else if (res && res.status === 'completed' && res.conclusion === 'failure') {
+              console.log('Workflow status is failed...');
+              process.exit(1);
+            } else if (res?.status !== '') {
+              console.log('Workflow status is ' + res?.status + '. Waiting for completion...');
+            } else {
+              console.log('Workflow status is unknown. Waiting for completion...');
+            }
+            attempt++;
+            console.log('Attempt: ' + attempt);
+            await new Promise(resolve => setTimeout(resolve, 60000)); // 60 seconds
+          }
+          if (attempt === MAX_ATTEMPTS) {
+            console.log('Max attempts reached without completion. Exiting.');
+            process.exit(1);
+          }
+        }
+        waitForWorkflowCompletion();" > script.js
+        node script.js
+    env:
+      GITHUB_TOKEN: ${{ secrets.SEAL5_ACCESS_TOKEN }}`

--- a/m2isar/backends/etiss/instruction_transform.py
+++ b/m2isar/backends/etiss/instruction_transform.py
@@ -559,13 +559,20 @@ def slice_operation(self: behav.SliceOperation, context: TransformerContext):
 		new_size = int(left.code.replace("U", "").replace("L", "")) - int(right.code.replace("U", "").replace("L", "")) + 1
 		mask = (1 << (int(left.code.replace("U", "").replace("L", "")) - int(right.code.replace("U", "").replace("L", "")) + 1)) - 1
 		mask = f"{mask}ULL"
+		simple_mask = True
 
 	# slice with actual lower and upper bound code if not possible to slice with integers
 	except ValueError:
 		new_size = expr.size
 		mask = f"((1 << (({left.code}) - ({right.code}) + 1)) - 1)"
+		simple_mask = False
 
-	c = CodeString(f"((({expr.code}) >> ({right.code})) & {mask})", static, new_size, expr.signed,
+	if simple_mask and (int(right.code.replace("U", "").replace("L", "")) == 0):
+		# no need to shift zeros steps
+		code = f"(({expr.code}) & {mask})"
+	else:
+		code = f"((({expr.code}) >> ({right.code})) & {mask})"
+	c = CodeString(code, static, new_size, expr.signed,
 		set.union(expr.regs_affected, left.regs_affected, right.regs_affected), [self.line_info] + expr.line_infos + left.line_infos + right.line_infos)
 	c.mem_ids = expr.mem_ids + left.mem_ids + right.mem_ids
 	return c

--- a/m2isar/backends/etiss/instruction_transform.py
+++ b/m2isar/backends/etiss/instruction_transform.py
@@ -472,7 +472,11 @@ def assignment(self: behav.Assignment, context: TransformerContext):
 
 	if not target.is_mem_access and not expr.is_mem_access:
 		if target.actual_size > target.size:
-			expr.code = f'({expr.code}) & {hex((1 << target.size) - 1)}'
+			if target.signed:
+				shift = target.actual_size - target.size
+				expr.code = f'(((etiss_int{target.actual_size})({expr.code})) << {shift}) >> {shift}'
+			else:
+				expr.code = f'({expr.code}) & {hex((1 << target.size) - 1)}'
 
 	else:
 		context.generates_exception = True

--- a/m2isar/backends/isa_manual/package.json
+++ b/m2isar/backends/isa_manual/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "datasheet": "1.3.0",
-    "npm": "^10.9.0"
+    "datasheet": "1.5.0"
   }
 }

--- a/m2isar/backends/isa_manual/writer.py
+++ b/m2isar/backends/isa_manual/writer.py
@@ -216,7 +216,7 @@ def main():
     if model_obj.model_version != M2_METAMODEL_VERSION:
         logger.warning("Loaded model version mismatch")
 
-    models = model_obj.models
+    models = model_obj.cores
 
     out_text = ""
 
@@ -262,12 +262,12 @@ def main():
                 writer.write_behavior2(instr_def.operation, drop_first=True)
                 behavior_text = writer.text
                 asm_str = None
-                if instr_def.disass:
-                    asm_str = instr_def.disass.replace("\"", "")
+                if instr_def.assembly:
+                    asm_str = instr_def.assembly.replace("\"", "")
                     asm_str = re.sub(r"{([a-zA-Z0-9]+)}", r"\g<1>", re.sub(r"{([a-zA-Z0-9]+):[#0-9a-zA-Z\.]+}", r"{\g<1>}", re.sub(r"name\(([a-zA-Z0-9]+)\)", r"\g<1>", asm_str)))
                 content_template = Template(MAKO_TEMPLATE_INSTR)
                 encoding_text = generate_encoding(instr_def.encoding)
-                content_text = content_template.render(name=instr_def.name, assembly=asm_str if asm_str else "N/A", mnemonic=instr_def.name.lower().replace("_", "."), encoding=encoding_text, attributes=instr_def.attributes, throws=arch.FunctionThrows(instr_def.throws), behavior=behavior_text)
+                content_text = content_template.render(name=instr_def.name, mnemonic=instr_def.mnemonic, assembly=asm_str if asm_str else "N/A", encoding=encoding_text, attributes=instr_def.attributes, throws=arch.FunctionThrows(instr_def.throws), behavior=behavior_text)
                 out_text += content_text
     with open(output_file, "w") as f:
         f.write(out_text)


### PR DESCRIPTION
When assigning signed values with a width such as `19` (`size=19`) to an intermediate variable. The ETISS generated JIT code has to use `int32_t` (1actual_size=321) as a datatype. The current implementation of the ETISS writer backend does not handle this properly.

There are two possible solutions for this:
1. Always sign extend from `size` to `actual_size` during the assignment. If the variable is used later, it behaves just like an `int32_t`.
2. Do the sign extension whenever the intermediate variable is used in the code. The assignment would have the upper 13 bits undefined.

This PR implements solution 1 as it seems to be the most straightforward and more efficient if the assignment is used more than once.

If `size == actual_size`, the sign extension can be omitted to optimize the JIT code.

**Additional Changes:**

This PR also contains a simple optimization that omits the generation of shifts with zero extend for slices which have a lower bit position of zero (e.g. `var[4:0]` or `var[31:0]`). Instead of `(var >> 0) & mask`, M2-ISA-R should generate just `var & mask`.