### PR TITLE
Remove monkey patch

### DIFF
--- a/m2isar/backends/coverage/coverage_dbg.py
+++ b/m2isar/backends/coverage/coverage_dbg.py
@@ -14,12 +14,12 @@ from collections import defaultdict
 
 from tqdm import tqdm
 
-from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch, patch_model
+from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch
 from ...metamodel.code_info import FunctionInfo, LineInfo
 from ...metamodel.utils.expr_preprocessor import (process_attributes,
                                                   process_functions,
                                                   process_instructions)
-from . import id_transform
+from .id_transform import IdTransformVisitor
 from .utils import IdMatcherContext
 
 logger = logging.getLogger("coverage_lcov")
@@ -66,7 +66,7 @@ def main():
 		process_attributes(core_obj)
 
 
-	patch_model(id_transform)
+	id_transform_visitor = IdTransformVisitor()
 
 	ctx = IdMatcherContext()
 
@@ -77,12 +77,12 @@ def main():
 			if fn_obj.function_info is not None:
 				ctx.id_to_obj_map[core_name][fn_obj.function_info.id] = fn_obj
 
-			fn_obj.operation.generate(ctx)
+			id_transform_visitor.generate(fn_obj.operation, ctx)
 
 		for instr_name, instr_obj in core_obj.instructions.items():
 			ctx.id_to_obj_map[core_name][instr_obj.function_info.id] = instr_obj
 
-			instr_obj.operation.generate(ctx)
+			id_transform_visitor.generate(instr_obj.operation, ctx)
 
 	id_to_obj_map = {}
 

--- a/m2isar/backends/coverage/coverage_lcov.py
+++ b/m2isar/backends/coverage/coverage_lcov.py
@@ -16,13 +16,13 @@ from functools import partial
 
 from tqdm.contrib.concurrent import process_map
 
-from ...metamodel import M2_METAMODEL_VERSION, M2Model, patch_model
+from ...metamodel import M2_METAMODEL_VERSION, M2Model
 from ...metamodel.code_info import (BranchInfo, CodeInfoBase, FunctionInfo,
                                     LineInfo)
 from ...metamodel.utils.expr_preprocessor import (process_attributes,
                                                   process_functions,
                                                   process_instructions)
-from . import id_transform
+from .id_transform import IdTransformVisitor
 from .utils import IdMatcherContext
 
 logger = logging.getLogger("coverage_lcov")
@@ -137,7 +137,7 @@ def main():
 
 	logger.info("building model-specific coverage database")
 
-	patch_model(id_transform)
+	id_transform_visitor = IdTransformVisitor()
 
 	ctx = IdMatcherContext()
 
@@ -148,12 +148,12 @@ def main():
 			if fn_obj.function_info is not None:
 				ctx.id_to_obj_map[core_name][fn_obj.function_info.id] = fn_obj
 
-			fn_obj.operation.generate(ctx)
+			id_transform_visitor.generate(fn_obj.operation, ctx)
 
 		for instr_name, instr_obj in core_obj.instructions.items():
 			ctx.id_to_obj_map[core_name][instr_obj.function_info.id] = instr_obj
 
-			instr_obj.operation.generate(ctx)
+			id_transform_visitor.generate(instr_obj.operation, ctx)
 
 
 	logger.info("initializing coverage counters")

--- a/m2isar/backends/coverage/id_transform.py
+++ b/m2isar/backends/coverage/id_transform.py
@@ -6,138 +6,138 @@
 # Chair of Electrical Design Automation
 # Technical University of Munich
 
+"""Visitor for mapping line/function IDs to model objects for coverage backends."""
 
 from ...metamodel import behav
+from ...metamodel.utils.ExprVisitor import ExprVisitor
 from .utils import IdMatcherContext
+from functools import singledispatchmethod
 
 
-def operation(self: behav.Operation, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+class IdTransformVisitor(ExprVisitor):
+	"""Visitor that builds a mapping from code info IDs to behavior objects."""
 
-	for stmt in self.statements:
-		stmt.generate(context)
+	@singledispatchmethod
+	def generate(self, expr: behav.BaseNode, context=None):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
 
-def block(self: behav.Block, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	def _store_id(self, expr: behav.BaseNode, context: "IdMatcherContext"):
+		if expr.line_info is not None:
+			context.id_to_obj_map[context.arch_name][expr.line_info.id] = expr
 
-	for stmt in self.statements:
-		stmt.generate(context)
+	@generate.register
+	def _(self, expr: behav.Operation, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		for stmt in expr.statements:
+			self.generate(stmt, context)
 
-def binary_operation(self: behav.BinaryOperation, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.Block, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		for stmt in expr.statements:
+			self.generate(stmt, context)
 
-	self.left.generate(context)
-	self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.BinaryOperation, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.left, context)
+		self.generate(expr.right, context)
 
-def slice_operation(self: behav.SliceOperation, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.SliceOperation, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.expr, context)
+		self.generate(expr.left, context)
+		self.generate(expr.right, context)
 
-	self.expr.generate(context)
-	self.left.generate(context)
-	self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.ConcatOperation, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.left, context)
+		self.generate(expr.right, context)
 
-def concat_operation(self: behav.ConcatOperation, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.NumberLiteral, context: "IdMatcherContext"):
+		self._store_id(expr, context)
 
-	self.left.generate(context)
-	self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.IntLiteral, context: "IdMatcherContext"):
+		self._store_id(expr, context)
 
-def number_literal(self: behav.IntLiteral, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.ScalarDefinition, context: "IdMatcherContext"):
+		self._store_id(expr, context)
 
-def int_literal(self: behav.IntLiteral, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.Break, context: "IdMatcherContext"):
+		self._store_id(expr, context)
 
-def scalar_definition(self: behav.ScalarDefinition, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.Assignment, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.target, context)
+		self.generate(expr.expr, context)
 
-def break_(self: behav.Break, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.Conditional, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		for cond in expr.conds:
+			self.generate(cond, context)
+		for stmt in expr.stmts:
+			self.generate(stmt, context)
 
-def assignment(self: behav.Assignment, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.Loop, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.cond, context)
+		for stmt in expr.stmts:
+			self.generate(stmt, context)
 
-	self.target.generate(context)
-	self.expr.generate(context)
+	@generate.register
+	def _(self, expr: behav.Ternary, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.cond, context)
+		self.generate(expr.then_expr, context)
+		self.generate(expr.else_expr, context)
 
-def conditional(self: behav.Conditional, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.Return, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		if expr.expr is not None:
+			self.generate(expr.expr, context)
 
-	for cond in self.conds:
-		cond.generate(context)
+	@generate.register
+	def _(self, expr: behav.UnaryOperation, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.right, context)
 
-	for stmt in self.stmts:
-		#
-		#for stmt in op:
-			stmt.generate(context)
-		#
+	@generate.register
+	def _(self, expr: behav.NamedReference, context: "IdMatcherContext"):
+		self._store_id(expr, context)
 
-def loop(self: behav.Loop, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.IndexedReference, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.index, context)
 
-	self.cond.generate(context)
+	@generate.register
+	def _(self, expr: behav.TypeConv, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.expr, context)
 
-	for stmt in self.stmts:
-		stmt.generate(context)
+	@generate.register
+	def _(self, expr: behav.Callable, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		for arg in expr.args:
+			self.generate(arg, context)
 
-def ternary(self: behav.Ternary, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
+	@generate.register
+	def _(self, expr: behav.ProcedureCall, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		for arg in expr.args:
+			self.generate(arg, context)
 
-	self.cond.generate(context)
-	self.then_expr.generate(context)
-	self.else_expr.generate(context)
-
-def return_(self: behav.Return, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
-
-	if self.expr is not None:
-		self.expr.generate(context)
-
-def unary_operation(self: behav.UnaryOperation, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
-
-	self.right.generate(context)
-
-def named_reference(self: behav.NamedReference, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
-
-def indexed_reference(self: behav.IndexedReference, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
-
-	self.index.generate(context)
-
-def type_conv(self: behav.TypeConv, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
-
-	self.expr.generate(context)
-
-def callable_(self: behav.Callable, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
-
-	for arg, arg_descr in zip(self.args, self.ref_or_name.args):
-		arg.generate(context)
-
-def group(self: behav.Group, context: "IdMatcherContext"):
-	if self.line_info is not None:
-		context.id_to_obj_map[context.arch_name][self.line_info.id] = self
-
-	self.expr.generate(context)
+	@generate.register
+	def _(self, expr: behav.Group, context: "IdMatcherContext"):
+		self._store_id(expr, context)
+		self.generate(expr.expr, context)

--- a/m2isar/backends/etiss/instruction_generator.py
+++ b/m2isar/backends/etiss/instruction_generator.py
@@ -12,8 +12,9 @@ import logging
 
 from mako.template import Template
 
-from ...metamodel import arch, behav, patch_model
-from . import BlockEndType, instruction_transform, instruction_utils
+from ...metamodel import arch, behav
+from . import BlockEndType, instruction_utils
+from .instruction_transform import InstructionTransformVisitor
 from .templates import template_dir
 
 logger = logging.getLogger("instruction_generator")
@@ -28,7 +29,7 @@ def generate_functions(core: arch.CoreDef, static_scalars: bool, decls_only: boo
 	"""
 
 	# load the instruction_transform generators
-	patch_model(instruction_transform)
+	visitor = InstructionTransformVisitor()
 
 	fn_template = Template(filename=str(template_dir/'etiss_function.mako'))
 
@@ -55,7 +56,7 @@ def generate_functions(core: arch.CoreDef, static_scalars: bool, decls_only: boo
 
 		if not decls_only:
 			fn_def.operation.line_info = fn_def.function_info
-			out_code = fn_def.operation.generate(context)
+			out_code = visitor.generate(fn_def.operation, context)
 			out_code.format(ARCH_NAME=core_name)
 
 		#fn_def.static = not context.used_arch_data
@@ -140,7 +141,7 @@ def generate_fields(core_default_width, instr_def: arch.Instruction):
 	return (fields_code, asm_printer_code, seen_fields, enc_idx)
 
 def generate_instruction_callback(core: arch.CoreDef, instr_def: arch.Instruction, fields, static_scalars: bool, block_end_on: BlockEndType, generate_coverage: bool):
-	patch_model(instruction_transform)
+	visitor = InstructionTransformVisitor()
 
 	instr_name = instr_def.name
 	core_name = core.name
@@ -169,7 +170,7 @@ def generate_instruction_callback(core: arch.CoreDef, instr_def: arch.Instructio
 	logger.debug("generating behavior code for %s", instr_def.name)
 
 	instr_def.operation.line_info = instr_def.function_info
-	out_code = instr_def.operation.generate(context)
+	out_code = visitor.generate(instr_def.operation, context)
 	out_code.format(ARCH_NAME=core_name)
 
 	logger.debug("rendering template for %s", instr_def.name)

--- a/m2isar/backends/etiss/instruction_transform.py
+++ b/m2isar/backends/etiss/instruction_transform.py
@@ -12,10 +12,12 @@ import logging
 from math import log2
 from itertools import chain
 from string import Template
+from functools import singledispatchmethod
 
 from ... import M2NameError, M2SyntaxError, M2ValueError, flatten
 from ...metamodel import arch, behav
 from ...metamodel.code_info import LineInfoPlacement
+from ...metamodel.utils.ExprVisitor import ExprVisitor
 from . import CodeInfoTracker, replacements
 from .instruction_utils import (FN_VAL_REPL, MEM_VAL_REPL, CodePartsContainer,
                                 CodeString, FnID, MemID, StaticType,
@@ -25,814 +27,729 @@ from .instruction_utils import (FN_VAL_REPL, MEM_VAL_REPL, CodePartsContainer,
 
 logger = logging.getLogger("instr_transform")
 
-def operation(self: behav.Operation, context: TransformerContext):
-	"""Generate an `Operation` model object. Essentially generate all children,
-	concatenate their code, and add exception behavior if needed.
-	"""
 
-	args: "list[CodeString]" = []
-	code_lines = []
+class InstructionTransformVisitor(ExprVisitor):
+	"""Visitor to transform M2-ISA-R model expressions to C code strings for ETISS."""
 
-	for stmt in self.statements:
-		c = stmt.generate(context)
+	@singledispatchmethod
+	def generate(self, expr: behav.BaseNode, context: TransformerContext):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(self).__name__}")
 
-		if isinstance(c, list):
-			args.extend(flatten(c))
+	@generate.register
+	def _(self, expr: behav.Operation, context: TransformerContext):
+		"""Generate an `Operation` model object."""
+
+		args: "list[CodeString]" = []
+		code_lines = []
+
+		for stmt in expr.statements:
+			c = self.generate(stmt, context)
+
+			if isinstance(c, list):
+				args.extend(flatten(c))
+			else:
+				args.append(c)
+
+		if expr.line_info is not None and context.generate_coverage:
+			CodeInfoTracker.insert(context.arch_name, expr.line_info)
+			code_lines.append(context.wrap_codestring(f"etiss_coverage_count(1, {expr.line_info.id});"))
+
+		for arg in args:
+			if arg.is_mem_access:
+				raise_fn_call = self.generate(behav.Conditional(
+					[behav.CodeLiteral('cpu->exception')],
+					[behav.ProcedureCall(
+						context.mem_raise_fn,
+						[behav.CodeLiteral("cpu->exception")]
+					)]
+				), context)
+
+				raise_fn_str = [context.wrap_codestring(c.code, c.static) for c in raise_fn_call]
+
+			before_line_infos = []
+			after_line_infos = []
+
+			if context.generate_coverage:
+				for l in flatten(arg.line_infos):
+					if l is not None:
+						CodeInfoTracker.insert(context.arch_name, l)
+
+						if l.placement == LineInfoPlacement.BEFORE:
+							before_line_infos.append(str(l.id))
+
+						elif l.placement == LineInfoPlacement.AFTER:
+							after_line_infos.append(str(l.id))
+
+			if len(before_line_infos) > 0:
+				code_lines.append(context.wrap_codestring(f"etiss_coverage_count({len(before_line_infos)}, {', '.join(before_line_infos)});"))
+
+			for f_id in arg.function_calls:
+				code_lines.append(context.wrap_codestring(f'{data_type_map[f_id.fn_call.data_type]}{f_id.fn_call.actual_size} {FN_VAL_REPL}{f_id.fn_id};', arg.static))
+				code_lines.append(context.wrap_codestring(f'{FN_VAL_REPL}{f_id.fn_id} = {f_id.args};', arg.static))
+				code_lines.append(context.wrap_codestring('if (cpu->return_pending) goto instr_exit_" + std::to_string(ic.current_address_) + ";', arg.static))
+
+			for m_id in arg.read_mem_ids:
+				code_lines.append(context.wrap_codestring(f'etiss_uint{m_id.access_size} {MEM_VAL_REPL}{m_id.mem_id};'))
+				code_lines.append(context.wrap_codestring(f'cpu->exception |= (*(system->dread))(system->handle, cpu, {m_id.index.code}, (etiss_uint8*)&{MEM_VAL_REPL}{m_id.mem_id}, {int(m_id.access_size / 8)});'))
+				code_lines.extend(raise_fn_str)
+
+			for m_id in arg.write_mem_ids:
+				code_lines.append(context.wrap_codestring(f'etiss_uint{m_id.access_size} {MEM_VAL_REPL}{m_id.mem_id};'))
+
+			code_lines.append(context.wrap_codestring(f'{arg.code}', arg.static))
+
+			if len(after_line_infos) > 0:
+				code_lines.append(context.wrap_codestring(f"etiss_coverage_count({len(after_line_infos)}, {', '.join(after_line_infos)});"))
+
+			for m_id in arg.write_mem_ids:
+				code_lines.append(context.wrap_codestring(f'cpu->exception |= (*(system->dwrite))(system->handle, cpu, {m_id.index.code}, (etiss_uint8*)&{MEM_VAL_REPL}{m_id.mem_id}, {int(m_id.access_size / 8)});'))
+				code_lines.extend(raise_fn_str)
+
+		container = CodePartsContainer()
+		container.initial_required = '\n'.join(code_lines)
+
+		if not context.ignore_static:
+			container.initial_required += '\ncp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\\n";'
+			container.initial_required += '\ncp.code() += "cpu->instructionPointer = cpu->nextPc;\\n";'
+			return_conditions = []
+			return_needed = any((
+				context.generates_exception,
+				arch.InstrAttribute.NO_CONT in context.attributes,
+				arch.InstrAttribute.COND in context.attributes,
+				arch.InstrAttribute.FLUSH in context.attributes
+			))
+
+			if context.generates_exception:
+				return_conditions.append("cpu->return_pending")
+				return_conditions.append("cpu->exception")
+
+			if arch.InstrAttribute.NO_CONT in context.attributes and arch.InstrAttribute.COND in context.attributes:
+				return_conditions.append(f'cpu->nextPc != " + std::to_string(ic.current_address_ + {int(context.instr_size / 8)}) + "ULL')
+
+			elif arch.InstrAttribute.NO_CONT in context.attributes:
+				return_conditions.clear()
+
+			if arch.InstrAttribute.FLUSH in context.attributes:
+				container.initial_required = 'cp.code() += "cpu->exception = ETISS_RETURNCODE_RELOADBLOCKS;\\n";\n' + container.initial_required
+				return_conditions.clear()
+
+			if return_needed:
+				cond_str = ("if (" + " || ".join(return_conditions) + ") ") if return_conditions else ""
+				container.appended_returning_required = f'cp.code() += "{cond_str}return cpu->exception;\\n";'
+
+		elif arch.FunctionAttribute.ETISS_TRAP_ENTRY_FN in context.attributes:
+			container.initial_required = "cpu->return_pending = 1;\ncpu->exception = 0;\n" + container.initial_required
+
+		return container
+
+	@generate.register
+	def _(self, expr: behav.Block, context: TransformerContext):
+		stmts = [self.generate(stmt, context) for stmt in expr.statements]
+
+		pre = [CodeString("{ // block", StaticType.READ, None, None, line_infos=expr.line_info)]
+		post = [CodeString("} // block", StaticType.READ, None, None)]
+
+		if not context.ignore_static:
+			pre.append(CodeString("{ // block", StaticType.NONE, None, None))
+			post.insert(0, CodeString("} // block", StaticType.NONE, None, None))
+
+		return pre + stmts + post
+
+	@generate.register
+	def _(self, expr: behav.Return, context: TransformerContext):
+		if context.instr_size != 0:
+			raise M2SyntaxError('Return statements are not allowed in instruction behavior!')
+
+		if expr.expr is not None:
+			c = self.generate(expr.expr, context)
+			c.code = f'return {c.code};'
+			c.line_infos.append(expr.line_info)
 		else:
-			args.append(c)
+			c = CodeString("return;", StaticType.RW, None, None, line_infos=expr.line_info)
 
-	if self.line_info is not None and context.generate_coverage:
-		CodeInfoTracker.insert(context.arch_name, self.line_info)
-		code_lines.append(context.wrap_codestring(f"etiss_coverage_count(1, {self.line_info.id});"))
+		return c
 
-	for arg in args:
-		if arg.is_mem_access:
-			raise_fn_call = behav.Conditional(
-				[behav.CodeLiteral('cpu->exception')],
-				[behav.ProcedureCall(
-					context.mem_raise_fn,
-					[behav.CodeLiteral("cpu->exception")]
-				)]
-			).generate(context)
+	@generate.register
+	def _(self, expr: behav.Break, context: TransformerContext):
+		return CodeString("break;", StaticType.RW, None, None, line_infos=expr.line_info)
 
-			raise_fn_str = [context.wrap_codestring(c.code, c.static) for c in raise_fn_call]
+	@generate.register
+	def _(self, expr: behav.ScalarDefinition, context: TransformerContext):
+		if context.static_scalars:
+			if context.ignore_static:
+				static = StaticType.RW
+			else:
+				static = expr.scalar.static
+		else:
+			static = StaticType.NONE
 
-		before_line_infos = []
-		after_line_infos = []
+		actual_size = 1 << (expr.scalar.size - 1).bit_length()
+		actual_size = max(actual_size, 8)
 
-		if context.generate_coverage:
-			for l in flatten(arg.line_infos):
-				if l is not None:
-					CodeInfoTracker.insert(context.arch_name, l)
+		return CodeString(
+			f'{data_type_map[expr.scalar.data_type]}{actual_size} {expr.scalar.name}',
+			static,
+			expr.scalar.size,
+			expr.scalar.data_type == arch.DataType.S,
+			line_infos=expr.line_info,
+		)
 
-					if l.placement == LineInfoPlacement.BEFORE:
-						before_line_infos.append(str(l.id))
+	@generate.register
+	def _(self, expr: behav.ProcedureCall, context: TransformerContext):
+		fn_args = [self.generate(arg, context) for arg in expr.args]
 
-					elif l.placement == LineInfoPlacement.AFTER:
-						after_line_infos.append(str(l.id))
+		ref = expr.ref_or_name if isinstance(expr.ref_or_name, arch.Function) else None
+		name = ref.name if isinstance(expr.ref_or_name, arch.Function) else expr.ref_or_name
 
-		if len(before_line_infos) > 0:
-			code_lines.append(context.wrap_codestring(f"etiss_coverage_count({len(before_line_infos)}, {', '.join(before_line_infos)});"))
+		if ref is not None:
+			fn = ref
+			static = StaticType.READ if fn.static and all(arg.static != StaticType.NONE for arg in fn_args) else StaticType.NONE
 
-		for f_id in arg.function_calls: # TODO: rework so that cascaded function calls and memory reads work properly
-			code_lines.append(context.wrap_codestring(f'{data_type_map[f_id.fn_call.data_type]}{f_id.fn_call.actual_size} {FN_VAL_REPL}{f_id.fn_id};', arg.static))
-			code_lines.append(context.wrap_codestring(f'{FN_VAL_REPL}{f_id.fn_id} = {f_id.args};', arg.static))
-			code_lines.append(context.wrap_codestring('if (cpu->return_pending) goto instr_exit_" + std::to_string(ic.current_address_) + ";', arg.static))
+			if not static:
+				context.used_arch_data = True
+				for arg in fn_args:
+					if arg.static and not arg.is_literal:
+						arg.code = context.make_static(arg.code, arg.signed)
 
-		for m_id in arg.read_mem_ids:
-			code_lines.append(context.wrap_codestring(f'etiss_uint{m_id.access_size} {MEM_VAL_REPL}{m_id.mem_id};'))
-			code_lines.append(context.wrap_codestring(f'cpu->exception |= (*(system->dread))(system->handle, cpu, {m_id.index.code}, (etiss_uint8*)&{MEM_VAL_REPL}{m_id.mem_id}, {int(m_id.access_size / 8)});'))
-			code_lines.extend(raise_fn_str)
+			arch_args = ['cpu', 'system', 'plugin_pointers'] if arch.FunctionAttribute.ETISS_NEEDS_ARCH in fn.attributes or (not fn.static and not fn.extern) else []
+			arg_str = ', '.join(arch_args + [arg.code for arg in fn_args])
 
-		for m_id in arg.write_mem_ids:
-			code_lines.append(context.wrap_codestring(f'etiss_uint{m_id.access_size} {MEM_VAL_REPL}{m_id.mem_id};'))
+			mem_ids = list(chain.from_iterable([arg.mem_ids for arg in fn_args]))
 
-		code_lines.append(context.wrap_codestring(f'{arg.code}', arg.static))
+			regs_affected = set(chain.from_iterable([arg.regs_affected for arg in fn_args]))
+			context.dependent_regs.update(regs_affected)
 
-		if len(after_line_infos) > 0:
-			code_lines.append(context.wrap_codestring(f"etiss_coverage_count({len(after_line_infos)}, {', '.join(after_line_infos)});"))
+			exc_code = ""
 
-		#if arg.check_trap:
-		#	code_lines.append(context.wrap_codestring('goto instr_exit_" + std::to_string(ic.current_address_) + ";'))
+			if arch.FunctionAttribute.ETISS_TRAP_TRANSLATE_FN in fn.attributes:
+				context.generates_exception = True
 
-		for m_id in arg.write_mem_ids:
-			code_lines.append(context.wrap_codestring(f'cpu->exception |= (*(system->dwrite))(system->handle, cpu, {m_id.index.code}, (etiss_uint8*)&{MEM_VAL_REPL}{m_id.mem_id}, {int(m_id.access_size / 8)});'))
-			code_lines.extend(raise_fn_str)
+			if arch.FunctionAttribute.ETISS_TRAP_ENTRY_FN in fn.attributes:
+				context.generates_exception = True
 
-	container = CodePartsContainer()
+				if fn.size is not None:
+					exc_code = "cpu->exception = "
 
-	container.initial_required = '\n'.join(code_lines)
+			c = CodeString(f'{exc_code}{fn.name}({arg_str});', static, None, None, line_infos=[expr.line_info] + [x.line_infos for x in fn_args])
+			c.mem_ids = mem_ids
+			if fn.throws and not context.ignore_static:
+				c.check_trap = True
 
-	# only generate return statements if not in a function
-	if not context.ignore_static:
-		container.initial_required += '\ncp.code() += "instr_exit_" + std::to_string(ic.current_address_) + ":\\n";'
-		container.initial_required += '\ncp.code() += "cpu->instructionPointer = cpu->nextPc;\\n";'# + code_str
-		return_conditions = []
-		return_needed = any((
-			context.generates_exception,
-			arch.InstrAttribute.NO_CONT in context.attributes,
-			arch.InstrAttribute.COND in context.attributes,
-			arch.InstrAttribute.FLUSH in context.attributes
-		))
+				cond = "if (cpu->return_pending) " if fn.throws == arch.FunctionThrows.MAYBE else ""
+				c2 = CodeString(cond + 'goto instr_exit_" + std::to_string(ic.current_address_) + ";', static, None, None)
 
-		if context.generates_exception:
-			return_conditions.append("cpu->return_pending")
-			return_conditions.append("cpu->exception")
+				pre = [CodeString("{ // procedure", StaticType.READ, None, None), CodeString("{ // procedure", StaticType.NONE, None, None)]
+				post = [CodeString("} // procedure", StaticType.NONE, None, None), CodeString("} // procedure", StaticType.READ, None, None)]
 
-		if arch.InstrAttribute.NO_CONT in context.attributes and arch.InstrAttribute.COND in context.attributes:
-			return_conditions.append(f'cpu->nextPc != " + std::to_string(ic.current_address_ + {int(context.instr_size / 8)}) + "ULL')
+				return pre + [c, c2] + post
 
-		elif arch.InstrAttribute.NO_CONT in context.attributes:
-			return_conditions.clear()
+			return c
 
-		if arch.InstrAttribute.FLUSH in context.attributes:
-			container.initial_required = 'cp.code() += "cpu->exception = ETISS_RETURNCODE_RELOADBLOCKS;\\n";\n' + container.initial_required
-			return_conditions.clear()
+		raise M2NameError(f'Function {name} not recognized!')
 
-		if return_needed:
-			cond_str = ("if (" + " || ".join(return_conditions) + ") ") if return_conditions else ""
-			container.appended_returning_required = f'cp.code() += "{cond_str}return cpu->exception;\\n";'
+	@generate.register
+	def _(self, expr: behav.FunctionCall, context: TransformerContext):
+		fn_args = [self.generate(arg, context) for arg in expr.args]
 
-	elif arch.FunctionAttribute.ETISS_TRAP_ENTRY_FN in context.attributes:
-		container.initial_required = "cpu->return_pending = 1;\ncpu->exception = 0;\n" + container.initial_required
+		ref = expr.ref_or_name if isinstance(expr.ref_or_name, arch.Function) else None
+		name = ref.name if isinstance(expr.ref_or_name, arch.Function) else expr.ref_or_name
 
-	return container
+		if ref is not None:
+			fn = ref
+			static = StaticType.READ if fn.static and all(arg.static != StaticType.NONE for arg in fn_args) else StaticType.NONE
 
-def block(self: behav.Block, context: TransformerContext):
-	stmts = [stmt.generate(context) for stmt in self.statements]
+			if not static:
+				context.used_arch_data = True
+				for arg in fn_args:
+					if arg.static and not arg.is_literal:
+						arg.code = context.make_static(arg.code, arg.signed)
 
-	pre = [CodeString("{ // block", StaticType.READ, None, None, line_infos=self.line_info)]
-	post = [CodeString("} // block", StaticType.READ, None, None)]
+			arch_args = ['cpu', 'system', 'plugin_pointers'] if arch.FunctionAttribute.ETISS_NEEDS_ARCH in fn.attributes or (not fn.static and not fn.extern) else []
+			arg_str = ', '.join(arch_args + [arg.code for arg in fn_args])
 
-	if not context.ignore_static:
-		pre.append(CodeString("{ // block", StaticType.NONE, None, None))
-		post.insert(0, CodeString("} // block", StaticType.NONE, None, None))
+			signed = fn.data_type == arch.DataType.S
+			regs_affected = set(chain.from_iterable([arg.regs_affected for arg in fn_args]))
 
-	return pre + stmts + post
+			c = CodeString(f'{fn.name}({arg_str})', static, fn.size, signed, regs_affected, [expr.line_info] + [x.line_infos for x in fn_args])
+			c.mem_ids = list(chain.from_iterable([arg.mem_ids for arg in fn_args]))
 
-def return_(self: behav.Return, context: TransformerContext):
-	if context.instr_size != 0:
-		raise M2SyntaxError('Return statements are not allowed in instruction behavior!')
+			if fn.throws and not context.ignore_static:
+				fn_id = FnID(fn, context.fn_var_count, c)
+				repl_c = CodeString(f'{FN_VAL_REPL}{context.fn_var_count}', static, fn.size, signed, regs_affected)
+				repl_c.mem_ids = list(chain.from_iterable([arg.mem_ids for arg in fn_args]))
+				repl_c.function_calls.append(fn_id)
+				context.fn_var_count += 1
+				return repl_c
 
-	if self.expr is not None:
-		c = self.expr.generate(context)
-		c.code = f'return {c.code};'
-		c.line_infos.append(self.line_info)
-	else:
-		c = CodeString("return;", StaticType.RW, None, None, line_infos=self.line_info)
+			return c
 
-	return c
+		raise M2NameError(f'Function {name} not recognized!')
 
-def break_(self: behav.Break, context: TransformerContext):
-	return CodeString("break;", StaticType.RW, None, None, line_infos=self.line_info)
+	@generate.register
+	def _(self, expr: behav.Callable, context: TransformerContext):
+		# Callable is the base class; dispatch to specific subclass handler
+		if isinstance(expr, behav.FunctionCall):
+			return self.generate(expr, context)
+		elif isinstance(expr, behav.ProcedureCall):
+			return self.generate(expr, context)
+		raise M2SyntaxError(f"Unsupported callable node type {type(expr).__name__}")
 
-def scalar_definition(self: behav.ScalarDefinition, context: TransformerContext):
-	"""Generate a scalar definition. Calculates the actual required data width and generates
-	a variable instantiation."""
+	@generate.register
+	def _(self, expr: behav.Assignment, context: TransformerContext):
+		target: CodeString = self.generate(expr.target, context)
+		expr_str: CodeString = self.generate(expr.expr, context)
 
-	if context.static_scalars:
+		static = bool(target.static & StaticType.WRITE) and bool(expr_str.static)
+
+		if not expr_str.static and bool(target.static & StaticType.WRITE) and not context.ignore_static:
+			raise M2ValueError('Static target cannot be assigned to non-static expression!')
+
+		if expr_str.static and not expr_str.is_literal:
+			if bool(target.static & StaticType.WRITE):
+				if context.ignore_static:
+					expr_str.code = Template(f'{expr_str.code}').safe_substitute(**replacements.rename_dynamic)
+				else:
+					expr_str.code = Template(f'{expr_str.code}').safe_substitute(**replacements.rename_static)
+			else:
+				expr_str.code = context.make_static(expr_str.code, expr_str.signed)
+
+		if bool(target.static & StaticType.READ):
+			target.code = Template(target.code).safe_substitute(replacements.rename_write)
+
+		context.affected_regs.update(target.regs_affected)
+		context.dependent_regs.update(expr_str.regs_affected)
+
+		if not target.is_mem_access and not expr_str.is_mem_access:
+			if target.actual_size > target.size:
+				if target.signed:
+					shift = target.actual_size - target.size
+					expr_str.code = f'(((etiss_int{target.actual_size})({expr_str.code})) << {shift}) >> {shift}'
+				else:
+					mask = (1 << target.size) - 1
+					mask_bits = log2(mask)
+					if mask_bits > 64:
+						mask64 = (1 << 64) - 1
+						low = mask & mask64
+						high = mask >> 64
+						mask_code = f"(((etiss_int128){hex(high)}ULL << 64) | {hex(low)}ULL)"
+					else:
+						mask_code = f"{hex(mask)}ULL"
+					expr_str.code = f'({expr_str.code}) & {mask_code}'
+		else:
+			context.generates_exception = True
+
+			for m_id in expr_str.mem_ids:
+				m_id.write = False
+
+				if not expr_str.mem_corrected:
+					logger.debug("assuming mem read size at %d", target.size)
+					m_id.access_size = target.size
+
+			if target.is_mem_access:
+				if len(target.mem_ids) != 1:
+					raise M2SyntaxError('Only one memory access is allowed as assignment target!')
+
+				target.mem_ids[0].write = True
+
+				if not target.mem_corrected:
+					logger.debug("assuming mem write size at %d", expr_str.size)
+					target.mem_ids[0].access_size = expr_str.size
+
+		c = CodeString(f"{target.code} = {expr_str.code};", static, None, None, line_infos=[expr.line_info] + target.line_infos + expr_str.line_infos)
+
+		c.function_calls.extend(target.function_calls)
+		c.function_calls.extend(expr_str.function_calls)
+
+		c.mem_ids.extend(target.mem_ids)
+		c.mem_ids.extend(expr_str.mem_ids)
+
+		return c
+
+	@generate.register
+	def _(self, expr: behav.BinaryOperation, context: TransformerContext):
+		left = self.generate(expr.left, context)
+		op = expr.op
+		right = self.generate(expr.right, context)
+
+		if not left.static and right.static and not right.is_literal:
+			right.code = context.make_static(right.code, right.signed)
+		if not right.static and left.static and not left.is_literal:
+			left.code = context.make_static(left.code, left.signed)
+
+		c = CodeString(
+			f'{left.code} {op.value} {right.code}',
+			left.static and right.static,
+			left.size if left.size > right.size else right.size,
+			left.signed or right.signed,
+			set.union(left.regs_affected, right.regs_affected),
+			[expr.line_info] + left.line_infos + right.line_infos,
+		)
+		c.mem_ids = left.mem_ids + right.mem_ids
+		return c
+
+	@generate.register
+	def _(self, expr: behav.UnaryOperation, context: TransformerContext):
+		op = expr.op
+		right = self.generate(expr.right, context)
+
+		c = CodeString(f'{op.value}({right.code})', right.static, right.size, right.signed, right.regs_affected, [expr.line_info] + right.line_infos)
+		c.mem_ids = right.mem_ids
+		return c
+
+	@generate.register
+	def _(self, expr: behav.Conditional, context: TransformerContext):
+		conds: "list[CodeString]" = [self.generate(x, context) for x in expr.conds]
+		stmts: "list[list[CodeString]]" = []
+
+		for cond in conds[1:]:
+			conds[0].mem_ids.extend(cond.mem_ids)
+			cond.mem_ids.clear()
+
+		for stmt in expr.stmts:
+			ret = self.generate(stmt, context)
+
+			if isinstance(ret, list):
+				stmts.append(ret)
+			else:
+				stmts.append([ret])
+
+		static = all(x.static for x in conds)
+		outputs: "list[CodeString]" = []
+
+		for cond in conds:
+			for m_id in cond.mem_ids:
+				m_id.write = False
+
+			if cond.static and not static:
+				cond.code = context.make_static(cond.code)
+				cond.static = False
+
+		conds[0].code = f'if ({conds[0].code}) {{ // conditional'
+		conds[0].line_infos.append(expr.line_info)
+		outputs.append(conds[0])
+		if not static:
+			context.dependent_regs.update(conds[0].regs_affected)
+
+		outputs.extend(flatten(stmts[0]))
+		outputs.append(CodeString("} // conditional", static, None, None))
+
+		for elif_cond, elif_stmts in zip(conds[1:], stmts[1:]):
+			elif_cond.code = f' else if ({elif_cond.code}) {{ // conditional'
+			outputs.append(elif_cond)
+			if not static:
+				context.dependent_regs.update(elif_cond.regs_affected)
+
+			outputs.extend(flatten(elif_stmts))
+			outputs.append(CodeString("} // conditional", static, None, None))
+
+		if len(conds) < len(stmts):
+			outputs.append(CodeString("else { // conditional", static, None, None))
+			outputs.extend(flatten(stmts[-1]))
+			outputs.append(CodeString("} // conditional", static, None, None))
+
+		return outputs
+
+	@generate.register
+	def _(self, expr: behav.Loop, context: TransformerContext):
+		cond: CodeString = self.generate(expr.cond, context)
+		stmts: "list[CodeString]" = []
+
+		for stmt in expr.stmts:
+			if isinstance(stmt, list):
+				for stmt2 in stmt:
+					stmts.append(self.generate(stmt2, context))
+			else:
+				stmts.append(self.generate(stmt, context))
+
+		if not cond.static:
+			context.dependent_regs.update(cond.regs_affected)
+
+		outputs: "list[CodeString]" = []
+
+		if expr.post_test:
+			start_c = CodeString("do", cond.static, None, None)
+			end_c = cond
+			end_c.code = f'while ({end_c.code})'
+		else:
+			start_c = cond
+			start_c.code = f'while ({start_c.code})'
+			end_c = CodeString("", cond.static, None, None)
+
+		outputs.append(start_c)
+		outputs.extend(flatten(stmts))
+		outputs.append(end_c)
+
+		return outputs
+
+	@generate.register
+	def _(self, expr: behav.Ternary, context: TransformerContext):
+		cond = self.generate(expr.cond, context)
+		then_expr = self.generate(expr.then_expr, context)
+		else_expr = self.generate(expr.else_expr, context)
+
+		static = StaticType.NONE not in [x.static for x in (cond, then_expr, else_expr)]
+
+		if not static:
+			if cond.static and not cond.is_literal:
+				cond.code = context.make_static(cond.code, cond.signed)
+			if then_expr.static and not then_expr.is_literal:
+				then_expr.code = context.make_static(then_expr.code, then_expr.signed)
+			if else_expr.static and not else_expr.is_literal:
+				else_expr.code = context.make_static(else_expr.code, else_expr.signed)
+
+		c = CodeString(
+			f'({cond}) ? ({then_expr}) : ({else_expr})',
+			static,
+			then_expr.size if then_expr.size > else_expr.size else else_expr.size,
+			then_expr.signed or else_expr.signed,
+			set.union(cond.regs_affected, then_expr.regs_affected, else_expr.regs_affected),
+			[expr.line_info] + cond.line_infos + then_expr.line_infos + else_expr.line_infos,
+		)
+		c.mem_ids = cond.mem_ids + then_expr.mem_ids + else_expr.mem_ids
+
+		return c
+
+	@generate.register
+	def _(self, expr: behav.TypeConv, context: TransformerContext):
+		expr_str = self.generate(expr.expr, context)
+
+		if expr.data_type is None:
+			expr.data_type = arch.DataType.S if expr_str.signed else arch.DataType.U
+
+		if expr.size is None:
+			expr.size = expr_str.size
+			expr.actual_size = expr_str.actual_size
+
+		if expr_str.is_mem_access:
+			if not expr_str.mem_corrected and expr_str.mem_ids[-1].access_size != expr.size:
+				expr_str.mem_ids[-1].access_size = expr.size
+				expr_str.size = expr.size
+				expr_str.mem_corrected = True
+			elif expr_str.mem_ids[-1].access_size == expr.size:
+				expr_str.mem_corrected = True
+
+		code_str = expr_str.code
+
+		if expr.data_type == arch.DataType.S and expr_str.actual_size != expr_str.size:
+			target_size = expr.actual_size
+
+			if isinstance(expr.size, int):
+				code_str = f'((etiss_int{target_size})(((etiss_int{target_size}){expr_str.code}) << ({target_size - expr.size})) >> ({target_size - expr.size}))'
+			else:
+				code_str = f'((etiss_int{target_size})(({expr_str.code}) << ({target_size} - {expr.size})) >> ({target_size} - {expr.size}))'
+		else:
+			code_str = f'({data_type_map[expr.data_type]}{expr.actual_size})({code_str})'
+
+		c = CodeString(code_str, expr_str.static, expr.size, expr.data_type == arch.DataType.S, expr_str.regs_affected, line_infos=[expr.line_info] + expr_str.line_infos)
+		c.mem_ids = expr_str.mem_ids
+		c.mem_corrected = expr_str.mem_corrected
+
+		return c
+
+	@generate.register
+	def _(self, expr: behav.NamedReference, context: TransformerContext):
+		referred_var = expr.reference
+		static = StaticType.NONE
+		name = referred_var.name
+
+		if name in replacements.rename_static:
+			name = f'${{{name}}}'
+			static = StaticType.READ
+
+		if isinstance(referred_var, arch.Memory):
+			if not static:
+				ref = "*" if len(referred_var.children) > 0 else ""
+				name = f"{ref}{replacements.default_prefix}{name}"
+			signed = False
+			size = referred_var.size
+			context.used_arch_data = True
+
+		elif isinstance(referred_var, arch.BitFieldDescr):
+			signed = referred_var.data_type == arch.DataType.S
+			size = referred_var.size
+			static = StaticType.READ
+
+		elif isinstance(referred_var, arch.Scalar):
+			signed = referred_var.data_type == arch.DataType.S
+			size = referred_var.size
+			if context.static_scalars:
+				static = referred_var.static
+
+		elif isinstance(referred_var, arch.Constant):
+			signed = referred_var.value < 0
+			size = context.native_size
+			static = StaticType.READ
+			name = f'{referred_var.value}'
+
+		elif isinstance(referred_var, arch.FnParam):
+			signed = referred_var.data_type == arch.DataType.S
+			size = referred_var.size
+			static = StaticType.RW
+
+		elif isinstance(referred_var, arch.Intrinsic):
+			if context.ignore_static:
+				raise TypeError("intrinsic not allowed in function")
+
+			signed = referred_var.data_type == arch.DataType.S
+			size = referred_var.size
+			static = StaticType.READ
+
+			if referred_var == context.intrinsics["__encoding_size"]:
+				name = str(context.instr_size // 8)
+
+		else:
+			raise TypeError("wrong type")
+
+		if context.ignore_static:
+			static = StaticType.RW
+
+		return CodeString(name, static, size, signed, line_infos=expr.line_info)
+
+	@generate.register
+	def _(self, expr: behav.IndexedReference, context: TransformerContext):
+		name = expr.reference.name
+		index = self.generate(expr.index, context)
+		referred_mem = expr.reference
+
+		if isinstance(referred_mem, arch.Memory):
+			context.used_arch_data = True
+
+		size = referred_mem.size
+
+		index_code = index.code
+		if index.static and not context.ignore_static and not index.is_literal:
+			index.code = context.make_static(index.code, index.signed)
+
 		if context.ignore_static:
 			static = StaticType.RW
 		else:
-			static = self.scalar.static
-	else:
-		static = StaticType.NONE
+			static = StaticType.NONE
 
-	actual_size = 1 << (self.scalar.size - 1).bit_length()
-	actual_size = max(actual_size, 8)
+		if arch.MemoryAttribute.IS_MAIN_MEM in referred_mem.attributes:
+			c = CodeString(f'{MEM_VAL_REPL}{context.mem_var_count}', static, size, False, line_infos=[expr.line_info] + index.line_infos)
+			c.mem_ids.append(MemID(referred_mem, context.mem_var_count, index, size))
+			context.mem_var_count += 1
+			return c
 
-	c = CodeString(f'{data_type_map[self.scalar.data_type]}{actual_size} {self.scalar.name}', static, self.scalar.size, self.scalar.data_type == arch.DataType.S, line_infos=self.line_info)
-	#c.scalar = self.scalar
-	return c
-
-def procedure_call(self: behav.ProcedureCall, context: TransformerContext):
-	"""Generate a procedure call (Function call without usage of the return value)."""
-
-	fn_args = [arg.generate(context) for arg in self.args]
-
-	# extract function object reference
-	ref = self.ref_or_name if isinstance(self.ref_or_name, arch.Function) else None
-	name = ref.name if isinstance(self.ref_or_name, arch.Function) else self.ref_or_name
-
-	if ref is not None:
-		# if there is a function object, use its information
-		fn = ref
-
-		# determine if procedure call is entirely static
-		static = StaticType.READ if fn.static and all(arg.static != StaticType.NONE for arg in fn_args) else StaticType.NONE
-
-		# convert singular static arguments
-		if not static:
-			context.used_arch_data = True
-			for arg in fn_args:
-				if arg.static and not arg.is_literal:
-					arg.code = context.make_static(arg.code, arg.signed)
-
-		# generate argument string, add ETISS arch data if required
-		arch_args = ['cpu', 'system', 'plugin_pointers'] if arch.FunctionAttribute.ETISS_NEEDS_ARCH in fn.attributes or (not fn.static and not fn.extern) else []
-		arg_str = ', '.join(arch_args + [arg.code for arg in fn_args])
-
-		# check if any argument is a memory access
-		mem_ids = list(chain.from_iterable([arg.mem_ids for arg in fn_args]))
-
-		# update affected and dependent registers
-		regs_affected = set(chain.from_iterable([arg.regs_affected for arg in fn_args]))
-		context.dependent_regs.update(regs_affected)
-
-		# add special behavior if this function is an exception entry point
-		exc_code = ""
-
-		if arch.FunctionAttribute.ETISS_TRAP_TRANSLATE_FN in fn.attributes:
-			context.generates_exception = True
-
-		if arch.FunctionAttribute.ETISS_TRAP_ENTRY_FN in fn.attributes:
-			context.generates_exception = True
-
-			if fn.size is not None:
-				exc_code = "cpu->exception = "
-
-		c = CodeString(f'{exc_code}{fn.name}({arg_str});', static, None, None, line_infos=[self.line_info] + [x.line_infos for x in fn_args])
-		c.mem_ids = mem_ids
-		if fn.throws and not context.ignore_static:
-			c.check_trap = True
-
-			cond = "if (cpu->return_pending) " if fn.throws == arch.FunctionThrows.MAYBE else ""
-			c2 = CodeString(cond + 'goto instr_exit_" + std::to_string(ic.current_address_) + ";', static, None, None)
-
-			pre = [CodeString("{ // procedure", StaticType.READ, None, None), CodeString("{ // procedure", StaticType.NONE, None, None)]
-			post = [CodeString("} // procedure", StaticType.NONE, None, None), CodeString("} // procedure", StaticType.READ, None, None)]
-
-			return pre + [c, c2] + post
-
+		code_str = f'{replacements.prefixes.get(name, replacements.default_prefix)}{name}[{index.code}]'
+		if len(referred_mem.children) > 0:
+			code_str = '*' + code_str
+		if size != referred_mem.size:
+			code_str = f'(etiss_uint{size})' + code_str
+		c = CodeString(code_str, static, size, False, line_infos=[expr.line_info] + index.line_infos)
+		if arch.MemoryAttribute.IS_MAIN_REG in referred_mem.attributes:
+			c.regs_affected.add(index_code)
 		return c
 
-	raise M2NameError(f'Function {name} not recognized!')
+	@generate.register
+	def _(self, expr: behav.SliceOperation, context: TransformerContext):
+		expr_str = self.generate(expr.expr, context)
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
 
-def function_call(self: behav.FunctionCall, context: TransformerContext):
-	"""Generate a regular function call (with further use of return value)."""
+		static = StaticType.NONE not in [x.static for x in (expr_str, left, right)]
 
-	fn_args = [arg.generate(context) for arg in self.args]
-
-	# extract function object reference
-	ref = self.ref_or_name if isinstance(self.ref_or_name, arch.Function) else None
-	name = ref.name if isinstance(self.ref_or_name, arch.Function) else self.ref_or_name
-
-	if ref is not None:
-		# if there is a function object, use its information
-
-		fn = ref
-
-		# determine if function call is entirely static
-		static = StaticType.READ if fn.static and all(arg.static != StaticType.NONE for arg in fn_args) else StaticType.NONE
-
-		# convert singular static arguments
 		if not static:
-			context.used_arch_data = True
-			for arg in fn_args:
-				if arg.static and not arg.is_literal:
-					arg.code = context.make_static(arg.code, arg.signed)
+			if expr_str.static and not expr_str.is_literal:
+				expr_str.code = context.make_static(expr_str.code, expr_str.signed)
+			if left.static and not left.is_literal:
+				left.code = context.make_static(left.code, left.signed)
+			if right.static and not right.is_literal:
+				right.code = context.make_static(right.code, right.signed)
 
-		# generate argument string, add ETISS arch data if required
-		arch_args = ['cpu', 'system', 'plugin_pointers'] if arch.FunctionAttribute.ETISS_NEEDS_ARCH in fn.attributes or (not fn.static and not fn.extern) else []
-		arg_str = ', '.join(arch_args + [arg.code for arg in fn_args])
+		try:
+			new_size = int(left.code.replace("U", "").replace("L", "")) - int(right.code.replace("U", "").replace("L", "")) + 1
+			mask = (1 << (int(left.code.replace("U", "").replace("L", "")) - int(right.code.replace("U", "").replace("L", "")) + 1)) - 1
+			mask_bits = log2(mask)
+			if mask_bits > 64:
+				mask64 = (1 << 64) - 1
+				low = mask & mask64
+				high = mask >> 64
+				mask_code = f"((((etiss_int128)){hex(high)}ULL << 64) | {hex(low)}ULL)"
+			else:
+				mask_code = f"{hex(mask)}ULL"
+			mask = f"{mask_code}"
+			simple_mask = True
+		except ValueError:
+			new_size = expr_str.size
+			mask = f"((1 << (({left.code}) - ({right.code}) + 1)) - 1)"
+			simple_mask = False
 
-		# keep track of signedness of function return value
-		signed = fn.data_type == arch.DataType.S
-		# keep track of affected registers
-		regs_affected = set(chain.from_iterable([arg.regs_affected for arg in fn_args]))
-
-		#goto_code = ""
-
-		#if fn.throws and not context.ignore_static:
-		#	goto_code = '; goto instr_exit_" + std::to_string(ic.current_address_) + "'
-
-		c = CodeString(f'{fn.name}({arg_str})', static, fn.size, signed, regs_affected, [self.line_info] + [x.line_infos for x in fn_args])
-		c.mem_ids = list(chain.from_iterable([arg.mem_ids for arg in fn_args]))
-
-		if fn.throws and not context.ignore_static:
-			fn_id = FnID(fn, context.fn_var_count, c)
-			repl_c = CodeString(f'{FN_VAL_REPL}{context.fn_var_count}', static, fn.size, signed, regs_affected)
-			repl_c.mem_ids = list(chain.from_iterable([arg.mem_ids for arg in fn_args]))
-			repl_c.function_calls.append(fn_id)
-			context.fn_var_count += 1
-			return repl_c
-
+		if simple_mask and (int(right.code.replace("U", "").replace("L", "")) == 0):
+			code = f"(({expr_str.code}) & {mask})"
+		else:
+			code = f"((({expr_str.code}) >> ({right.code})) & {mask})"
+		c = CodeString(code, static, new_size, expr_str.signed,
+			set.union(expr_str.regs_affected, left.regs_affected, right.regs_affected), [expr.line_info] + expr_str.line_infos + left.line_infos + right.line_infos)
+		c.mem_ids = expr_str.mem_ids + left.mem_ids + right.mem_ids
 		return c
 
-	raise M2NameError(f'Function {name} not recognized!')
-
-def conditional(self: behav.Conditional, context: TransformerContext):
-	"""Generate a conditional ('if' with optional 'else if' and 'else' blocks)"""
-
-	# generate conditions and statement blocks
-	conds: "list[CodeString]" = [x.generate(context) for x in self.conds]
-	stmts: "list[list[CodeString]]" = [] #= [[y.generate(context) for y in x] for x in self.stmts]
-
-	for cond in conds[1:]:
-		conds[0].mem_ids.extend(cond.mem_ids)
-		cond.mem_ids.clear()
-
-	for stmt in self.stmts:
-		ret = stmt.generate(context)
-
-		if isinstance(ret, list):
-			stmts.append(ret)
-		else:
-			stmts.append([ret])
-
-	#for stmt_block in self.stmts:
-	#	block_statements = []
-	#	for stmt in stmt_block:
-	#		if isinstance(stmt, list):
-	#			for stmt2 in stmt:
-	#				block_statements.append(stmt2.generate(context))
-	#		else:
-	#			block_statements.append(stmt.generate(context))
-
-	#	stmts.append(block_statements)
-
-	# check if all conditions are static
-	static = all(x.static for x in conds)
-
-	outputs: "list[CodeString]" = []
-
-	for cond in conds:
-		for m_id in cond.mem_ids:
-			m_id.write = False
-
-		if cond.static and not static:
-			cond.code = context.make_static(cond.code)
-			cond.static = False
-
-	# generate initial if
-	#c = conds[0]
-	conds[0].code = f'if ({conds[0].code}) {{ // conditional'
-	conds[0].line_infos.append(self.line_info)
-	outputs.append(conds[0])
-	if not static:
-		context.dependent_regs.update(conds[0].regs_affected)
-
-	# generate first statement block
-	outputs.extend(flatten(stmts[0]))
-
-	# generate closing brace
-	outputs.append(CodeString("} // conditional", static, None, None))
-
-	for elif_cond, elif_stmts in zip(conds[1:], stmts[1:]):
-		elif_cond.code = f' else if ({elif_cond.code}) {{ // conditional'
-		outputs.append(elif_cond)
-		if not static:
-			context.dependent_regs.update(elif_cond.regs_affected)
-
-		outputs.extend(flatten(elif_stmts))
-
-		outputs.append(CodeString("} // conditional", static, None, None))
-
-	if len(conds) < len(stmts):
-		outputs.append(CodeString("else { // conditional", static, None, None))
-
-		outputs.extend(flatten(stmts[-1]))
-
-		outputs.append(CodeString("} // conditional", static, None, None))
-
-	return outputs
-
-def loop(self: behav.Loop, context: TransformerContext):
-	"""Generate 'while' and 'do .. while' loops."""
-
-	# generate the loop condition and body
-	cond: CodeString = self.cond.generate(context)
-	stmts: "list[CodeString]" = [] #[stmt.generate(context) for stmt in self.stmts]
-
-	for stmt in self.stmts:
-		if isinstance(stmt, list):
-			for stmt2 in stmt:
-				stmts.append(stmt2.generate(context))
-		else:
-			stmts.append(stmt.generate(context))
-
-	if not cond.static:
-		context.dependent_regs.update(cond.regs_affected)
-
-	outputs: "list[CodeString]" = []
-
-	if self.post_test:
-		start_c = CodeString("do", cond.static, None, None)
-		end_c = cond
-		end_c.code = f'while ({end_c.code})'
-	else:
-		start_c = cond
-		start_c.code = f'while ({start_c.code})'
-		end_c = CodeString("", cond.static, None, None)
-
-	outputs.append(start_c)
-
-	outputs.extend(flatten(stmts))
-
-	outputs.append(end_c)
-
-	return outputs
-
-def ternary(self: behav.Ternary, context: TransformerContext):
-	"""Generate a ternary expression."""
-
-	# generate condition and 'then' and 'else' statements
-	cond = self.cond.generate(context)
-	then_expr = self.then_expr.generate(context)
-	else_expr = self.else_expr.generate(context)
-
-	static = StaticType.NONE not in [x.static for x in (cond, then_expr, else_expr)]
-
-	# convert singular static sub-components
-	if not static:
-		if cond.static and not cond.is_literal:
-			cond.code = context.make_static(cond.code, cond.signed)
-		if then_expr.static and not then_expr.is_literal:
-			then_expr.code = context.make_static(then_expr.code, then_expr.signed)
-		if else_expr.static and not else_expr.is_literal:
-			else_expr.code = context.make_static(else_expr.code, else_expr.signed)
-
-	c = CodeString(f'({cond}) ? ({then_expr}) : ({else_expr})', static, then_expr.size if then_expr.size > else_expr.size else else_expr.size,
-		then_expr.signed or else_expr.signed, set.union(cond.regs_affected, then_expr.regs_affected, else_expr.regs_affected), [self.line_info] + cond.line_infos + then_expr.line_infos + else_expr.line_infos)
-	c.mem_ids = cond.mem_ids + then_expr.mem_ids + else_expr.mem_ids
-
-	return c
-
-def assignment(self: behav.Assignment, context: TransformerContext):
-	"""Generate an assignment expression"""
-
-	# generate target and value expressions
-	target: CodeString = self.target.generate(context)
-	expr: CodeString = self.expr.generate(context)
-
-	# check staticness
-	static = bool(target.static & StaticType.WRITE) and bool(expr.static)
-
-	# error out if a static target should be assigned a non-static value
-	if not expr.static and bool(target.static & StaticType.WRITE) and not context.ignore_static:
-		raise M2ValueError('Static target cannot be assigned to non-static expression!')
-
-	# convert assignment value staticness
-	if expr.static and not expr.is_literal:
-		if bool(target.static & StaticType.WRITE):
-			if context.ignore_static:
-				expr.code = Template(f'{expr.code}').safe_substitute(**replacements.rename_dynamic)
-			else:
-				expr.code = Template(f'{expr.code}').safe_substitute(**replacements.rename_static)
-
-		else:
-			expr.code = context.make_static(expr.code, expr.signed)
-
-	# convert target staticness
-	if bool(target.static & StaticType.READ):
-		target.code = Template(target.code).safe_substitute(replacements.rename_write)
-
-	# keep track of affected and dependent registers
-	context.affected_regs.update(target.regs_affected)
-	context.dependent_regs.update(expr.regs_affected)
-
-	if not target.is_mem_access and not expr.is_mem_access:
-		if target.actual_size > target.size:
-			if target.signed:
-				shift = target.actual_size - target.size
-				expr.code = f'(((etiss_int{target.actual_size})({expr.code})) << {shift}) >> {shift}'
-			else:
-				mask = (1 << target.size) - 1
-				mask_bits = log2(mask)
-				if mask_bits > 64:
-					mask64 = (1 << 64) - 1
-					low = mask & mask64
-					high = mask >> 64
-					mask_code = f"(((etiss_int128){hex(high)}ULL << 64) | {hex(low)}ULL)"
-				else:
-					mask_code = f"{hex(mask)}ULL"
-				expr.code = f'({expr.code}) & {mask_code}'
-
-	else:
-		context.generates_exception = True
-
-		for m_id in expr.mem_ids:
-			m_id.write = False
-
-			if not expr.mem_corrected:
-				logger.debug("assuming mem read size at %d", target.size)
-				m_id.access_size = target.size
-
-		if target.is_mem_access:
-			if len(target.mem_ids) != 1:
-				raise M2SyntaxError('Only one memory access is allowed as assignment target!')
-
-			target.mem_ids[0].write = True
-
-			if not target.mem_corrected:
-				logger.debug("assuming mem write size at %d", expr.size)
-				target.mem_ids[0].access_size = expr.size
-
-	c = CodeString(f"{target.code} = {expr.code};", static, None, None, line_infos=[self.line_info] + target.line_infos + expr.line_infos)
-
-	c.function_calls.extend(target.function_calls)
-	c.function_calls.extend(expr.function_calls)
-
-	c.mem_ids.extend(target.mem_ids)
-	c.mem_ids.extend(expr.mem_ids)
-
-	return c
-
-def binary_operation(self: behav.BinaryOperation, context: TransformerContext):
-	"""Generate a binary expression"""
-
-	# generate LHS and RHS of the expression
-	left = self.left.generate(context)
-	op = self.op
-	right = self.right.generate(context)
-
-	# convert staticness if needed
-	if not left.static and right.static and not right.is_literal:
-		right.code = context.make_static(right.code, right.signed)
-	if not right.static and left.static and not left.is_literal:
-		left.code = context.make_static(left.code, left.signed)
-
-	c = CodeString(f'{left.code} {op.value} {right.code}', left.static and right.static, left.size if left.size > right.size else right.size,
-		left.signed or right.signed, set.union(left.regs_affected, right.regs_affected), [self.line_info] + left.line_infos + right.line_infos)
-	# keep track of any memory accesses
-	c.mem_ids = left.mem_ids + right.mem_ids
-	return c
-
-def unary_operation(self: behav.UnaryOperation, context: TransformerContext):
-	op = self.op
-	right = self.right.generate(context)
-
-	c = CodeString(f'{op.value}({right.code})', right.static, right.size, right.signed, right.regs_affected, [self.line_info] + right.line_infos)
-	c.mem_ids = right.mem_ids
-	return c
-
-def slice_operation(self: behav.SliceOperation, context: TransformerContext):
-	"""Generate a slice expression"""
-
-	# generate expression to be sliced and lower and upper slice bound
-	expr = self.expr.generate(context)
-	left = self.left.generate(context)
-	right = self.right.generate(context)
-
-	static = StaticType.NONE not in [x.static for x in (expr, left, right)]
-
-	if not static:
-		if expr.static and not expr.is_literal:
-			expr.code = context.make_static(expr.code, expr.signed)
-		if left.static and not left.is_literal:
-			left.code = context.make_static(left.code, left.signed)
-		if right.static and not right.is_literal:
+	@generate.register
+	def _(self, expr: behav.ConcatOperation, context: TransformerContext):
+		left: CodeString = self.generate(expr.left, context)
+		right: CodeString = self.generate(expr.right, context)
+
+		if not left.static and right.static and not right.is_literal:
 			right.code = context.make_static(right.code, right.signed)
+		if not right.static and left.static and not left.is_literal:
+			left.code = context.make_static(left.code, left.signed)
 
-	# slice with fixed integers if slice bounds are integers
-	try:
-		new_size = int(left.code.replace("U", "").replace("L", "")) - int(right.code.replace("U", "").replace("L", "")) + 1
-		mask = (1 << (int(left.code.replace("U", "").replace("L", "")) - int(right.code.replace("U", "").replace("L", "")) + 1)) - 1
-		mask_bits = log2(mask)
-		if mask_bits > 64:
-			mask64 = (1 << 64) - 1
-			low = mask & mask64
-			high = mask >> 64
-			mask_code = f"((((etiss_int128)){hex(high)}ULL << 64) | {hex(low)}ULL)"
-		else:
-			mask_code = f"{hex(mask)}ULL"
-		mask = f"{mask_code}"
-		simple_mask = True
-
-	# slice with actual lower and upper bound code if not possible to slice with integers
-	except ValueError:
-		new_size = expr.size
-		mask = f"((1 << (({left.code}) - ({right.code}) + 1)) - 1)"
-		simple_mask = False
-
-	if simple_mask and (int(right.code.replace("U", "").replace("L", "")) == 0):
-		# no need to shift zeros steps
-		code = f"(({expr.code}) & {mask})"
-	else:
-		code = f"((({expr.code}) >> ({right.code})) & {mask})"
-	c = CodeString(code, static, new_size, expr.signed,
-		set.union(expr.regs_affected, left.regs_affected, right.regs_affected), [self.line_info] + expr.line_infos + left.line_infos + right.line_infos)
-	c.mem_ids = expr.mem_ids + left.mem_ids + right.mem_ids
-	return c
-
-def concat_operation(self: behav.ConcatOperation, context: TransformerContext):
-	"""Generate a concatenation expression"""
-
-	# generate LHS and RHS operands
-	left: CodeString = self.left.generate(context)
-	right: CodeString = self.right.generate(context)
-
-	if not left.static and right.static and not right.is_literal:
-		right.code = context.make_static(right.code, right.signed)
-	if not right.static and left.static and not left.is_literal:
-		left.code = context.make_static(left.code, left.signed)
-
-	new_size = left.size + right.size
-	c = CodeString(f"((({left.code}) << {right.size}) | ({right.code}))", left.static and right.static, new_size, left.signed or right.signed,
-		set.union(left.regs_affected, right.regs_affected), [self.line_info] + left.line_infos + right.line_infos)
-	c.mem_ids = left.mem_ids + right.mem_ids
-	return c
-
-def named_reference(self: behav.NamedReference, context: TransformerContext):
-	"""Generate a named reference"""
-
-	# extract referred object
-	referred_var = self.reference
-
-	static = StaticType.NONE
-
-	name = referred_var.name
-
-	# check if static name replacement is needed
-	if name in replacements.rename_static:
-		name = f'${{{name}}}'
-		static = StaticType.READ
-
-	# check which type of reference has to be generated
-	if isinstance(referred_var, arch.Memory):
-		# architecture memory object (register, memory interface)
-		if not static:
-			ref = "*" if len(referred_var.children) > 0 else ""
-			name = f"{ref}{replacements.default_prefix}{name}"
-		signed = False
-		size = referred_var.size
-		context.used_arch_data = True
-
-	elif isinstance(referred_var, arch.BitFieldDescr):
-		# instruction encoding operand
-		signed = referred_var.data_type == arch.DataType.S
-		size = referred_var.size
-		static = StaticType.READ
-
-	elif isinstance(referred_var, arch.Scalar):
-		# scalar
-		signed = referred_var.data_type == arch.DataType.S
-		size = referred_var.size
-		if context.static_scalars:
-			static = referred_var.static
-
-	elif isinstance(referred_var, arch.Constant):
-		# architecture constant
-		signed = referred_var.value < 0
-		size = context.native_size
-		static = StaticType.READ
-		name = f'{referred_var.value}'
-
-	elif isinstance(referred_var, arch.FnParam):
-		# function argument
-		signed = referred_var.data_type == arch.DataType.S
-		size = referred_var.size
-		static = StaticType.RW
-
-	elif isinstance(referred_var, arch.Intrinsic):
-		if context.ignore_static:
-			raise TypeError("intrinsic not allowed in function")
-
-		signed = referred_var.data_type == arch.DataType.S
-		size = referred_var.size
-		static = StaticType.READ
-
-		if referred_var == context.intrinsics["__encoding_size"]:
-			name = str(context.instr_size // 8)
-
-	else:
-		# should not happen
-		raise TypeError("wrong type")
-
-	if context.ignore_static:
-		static = StaticType.RW
-
-	c = CodeString(name, static, size, signed, line_infos=self.line_info)
-	#c.scalar = scalar
-	return c
-
-def indexed_reference(self: behav.IndexedReference, context: TransformerContext):
-	"""Generate an indexed reference expression (for register banks or memory)."""
-
-	name = self.reference.name
-
-	# generate index expression
-	index = self.index.generate(context)
-
-	referred_mem = self.reference
-
-	if isinstance(referred_mem, arch.Memory):
-		context.used_arch_data = True
-
-	size = referred_mem.size
-
-	# convert static index expression
-	index_code = index.code
-	if index.static and not context.ignore_static and not index.is_literal:
-		index.code = context.make_static(index.code, index.signed)
-
-	if context.ignore_static:
-		static = StaticType.RW
-	else:
-		static = StaticType.NONE
-
-	if arch.MemoryAttribute.IS_MAIN_MEM in referred_mem.attributes:
-		# generate memory access if main memory is accessed
-		c = CodeString(f'{MEM_VAL_REPL}{context.mem_var_count}', static, size, False, line_infos=[self.line_info] + index.line_infos)
-		c.mem_ids.append(MemID(referred_mem, context.mem_var_count, index, size))
-		context.mem_var_count += 1
+		new_size = left.size + right.size
+		c = CodeString(f"((({left.code}) << {right.size}) | ({right.code}))", left.static and right.static, new_size, left.signed or right.signed,
+			set.union(left.regs_affected, right.regs_affected), [expr.line_info] + left.line_infos + right.line_infos)
+		c.mem_ids = left.mem_ids + right.mem_ids
 		return c
 
-	# generate normal indexed access if not
-	code_str = f'{replacements.prefixes.get(name, replacements.default_prefix)}{name}[{index.code}]'
-	if len(referred_mem.children) > 0:
-		code_str = '*' + code_str
-	if size != referred_mem.size:
-		code_str = f'(etiss_uint{size})' + code_str
-	c = CodeString(code_str, static, size, False, line_infos=[self.line_info] + index.line_infos)
-	if arch.MemoryAttribute.IS_MAIN_REG in referred_mem.attributes:
-		c.regs_affected.add(index_code)
-	return c
+	@generate.register
+	def _(self, expr: behav.NumberLiteral, context: TransformerContext):
+		lit = int(expr.value)
+		size = min(lit.bit_length(), 64)
+		sign = lit < 0
 
-def type_conv(self: behav.TypeConv, context: TransformerContext):
-	"""Generate a type cast expression"""
+		twocomp_lit = (lit + (1 << 64)) % (1 << 64)
 
-	# generate the expression to be type-casted
-	expr = self.expr.generate(context)
+		postfix = "U" if not sign else ""
+		postfix += "LL"
 
-	# if only width should be changed assume data type remains unchanged
-	if self.data_type is None:
-		self.data_type = arch.DataType.S if expr.signed else arch.DataType.U
+		return CodeString(str(twocomp_lit) + postfix, True, size, sign, line_infos=expr.line_info)
 
-	# if only data type should be changed assume width remains unchanged
-	if self.size is None:
-		self.size = expr.size
-		self.actual_size = expr.actual_size
+	@generate.register
+	def _(self, expr: behav.IntLiteral, context: TransformerContext):
+		lit = int(expr.value)
+		size = min(expr.bit_size, 128)
+		sign = expr.signed
 
-	# save access size for memory access
-	if expr.is_mem_access:
-		if not expr.mem_corrected and expr.mem_ids[-1].access_size != self.size:
-			expr.mem_ids[-1].access_size = self.size
-			expr.size = self.size
-			expr.mem_corrected = True
-		elif expr.mem_ids[-1].access_size == self.size:
-			expr.mem_corrected = True
+		minus = ""
+		if lit > 0 and sign and (lit >> (size - 1)) & 1:
+			minus = "-"
 
-	code_str = expr.code
+		_ = (lit + (1 << size)) % (1 << size)
 
-	# sign extension for non-2^N datatypes
-	if self.data_type == arch.DataType.S and expr.actual_size != expr.size:
-		target_size = self.actual_size
+		postfix = "U" if not sign else ""
+		postfix += "LL"
 
-		if isinstance(self.size, int):
-			code_str = f'((etiss_int{target_size})(((etiss_int{target_size}){expr.code}) << ({target_size - expr.size})) >> ({target_size - expr.size}))'
+		ret = CodeString(minus + str(lit) + postfix, True, size, sign, line_infos=expr.line_info)
+		ret.is_literal = True
+		return ret
+
+	@generate.register
+	def _(self, expr: behav.StringLiteral, context: TransformerContext):
+		return CodeString(f'"{expr.value}"', StaticType.READ, None, False, line_infos=expr.line_info)
+
+	@generate.register
+	def _(self, expr: behav.CodeLiteral, context: TransformerContext):
+		return CodeString(expr.val, False, context.native_size, False, line_infos=expr.line_info)
+
+	@generate.register
+	def _(self, expr: behav.Operator, context: TransformerContext):
+		return expr.value
+
+	@generate.register
+	def _(self, expr: behav.Group, context: TransformerContext):
+		expr_str = self.generate(expr.expr, context)
+		if isinstance(expr_str, CodeString):
+			expr_str.code = f'({expr_str.code})'
+			expr_str.line_infos.append(expr.line_info)
 		else:
-			code_str = f'((etiss_int{target_size})(({expr.code}) << ({target_size} - {expr.size})) >> ({target_size} - {expr.size}))'
-
-	# normal type conversion
-	# TODO: check if behavior adheres to CoreDSL 2 spec
-	else:
-		code_str = f'({data_type_map[self.data_type]}{self.actual_size})({code_str})'
-
-	c = CodeString(code_str, expr.static, self.size, self.data_type == arch.DataType.S, expr.regs_affected, line_infos=[self.line_info] + expr.line_infos)
-	c.mem_ids = expr.mem_ids
-	c.mem_corrected = expr.mem_corrected
-
-	return c
-
-def int_literal(self: behav.IntLiteral, context: TransformerContext):
-	"""Generate an integer literal."""
-
-	lit = int(self.value)
-	size = min(self.bit_size, 128)
-	sign = self.signed
-
-	minus = ""
-	if lit > 0 and sign and (lit >> (size - 1)) & 1:
-		minus = "-"
-
-	twocomp_lit = (lit + (1 << size)) % (1 << size)
-
-	# add c postfix for large numbers
-	postfix = "U" if not sign else ""
-	postfix += "LL"
-	#postfix = "ULL"
-	#if size > 32:
-	#	postfix += "L"
-	#if size > 64:
-	#	postfix += "L"
-
-	ret = CodeString(minus + str(lit) + postfix, True, size, sign, line_infos=self.line_info)
-	ret.is_literal = True
-	return ret
-
-def number_literal(self: behav.NumberLiteral, context: TransformerContext):
-	"""Generate generic number literal. Currently unused."""
-
-	lit = int(self.value)
-	size = min(lit.bit_length(), 64)
-	sign = lit < 0
-
-	twocomp_lit = (lit + (1 << 64)) % (1 << 64)
-
-	postfix = "U" if not sign else ""
-	postfix += "LL"
-	#postfix = "ULL"
-	#if size > 32:
-	#	postfix += "L"
-	#if size > 64:
-	#	postfix += "L"
-
-	return CodeString(str(twocomp_lit) + postfix, True, size, sign, line_infos=self.line_info)
-
-def group(self: behav.Group, context: TransformerContext):
-	"""Generate a group of expressions."""
-
-	expr = self.expr.generate(context)
-	if isinstance(expr, CodeString):
-		expr.code = f'({expr.code})'
-		expr.line_infos.append(self.line_info)
-	else:
-		expr = f'({expr})'
-	return expr
-
-def operator(self: behav.Operator, context: TransformerContext):
-	return self.op
-
-def code_literal(self: behav.CodeLiteral, context: TransformerContext):
-	return CodeString(self.val, False, context.native_size, False, line_infos=self.line_info)
+			expr_str = f'({expr_str})'
+		return expr_str

--- a/m2isar/backends/isa_manual/visitor.py
+++ b/m2isar/backends/isa_manual/visitor.py
@@ -9,161 +9,166 @@
 """Visitor for traversing the behavior in the metamodel and generating the CoreDSL2 syntax."""
 
 from m2isar.metamodel import arch, behav
+from m2isar.metamodel.utils.ExprVisitor import ExprVisitor
+from functools import singledispatchmethod
 
 # pylint: disable=unused-argument
 
 
-def operation(self: behav.Operation, writer):
-    if len(self.statements) > 1:
+class ISAmanualVisitor(ExprVisitor):
+    """Visitor for generating ISA manual CoreDSL2-like behavior text."""
+
+    @singledispatchmethod
+    def generate(self, expr: behav.BaseNode, context=None):
+        raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(self).__name__}")
+
+    @generate.register
+    def _(self, expr: behav.Operation, writer):
+        if len(expr.statements) > 1:
+            writer.enter_block()
+        for stmt in expr.statements:
+            self.generate(stmt, writer)
+            if not isinstance(stmt, (behav.Conditional, behav.Operation)):
+                writer.write_line(";")
+        if len(expr.statements) > 1:
+            writer.leave_block()
+
+    @generate.register
+    def _(self, expr: behav.BinaryOperation, writer):
+        self.generate(expr.left, writer)
+        writer.write(f" {expr.op.value} ")
+        self.generate(expr.right, writer)
+
+    @generate.register
+    def _(self, expr: behav.SliceOperation, writer):
+        self.generate(expr.expr, writer)
+        writer.write("[")
+        self.generate(expr.left, writer)
+        writer.write(":")
+        self.generate(expr.right, writer)
+        writer.write("]")
+
+    @generate.register
+    def _(self, expr: behav.ConcatOperation, writer):
+        self.generate(expr.left, writer)
+        writer.write(" :: ")
+        self.generate(expr.right, writer)
+
+    @generate.register
+    def _(self, expr: behav.IntLiteral, writer):
+        writer.write(expr.value)
+
+    @generate.register
+    def _(self, expr: behav.IntLiteral, writer):
+        writer.write(expr.value)
+
+    @generate.register
+    def _(self, expr: behav.ScalarDefinition, writer):
+        writer.write_type(expr.scalar.data_type, expr.scalar.size)
+        writer.write(" ")
+        writer.write(expr.scalar.name)
+        if expr.scalar.value:
+            writer.write(" = ")
+            writer.write(expr.scalar.value)
+
+    @generate.register
+    def _(self, expr: behav.Break, writer):
+        writer.write_line("break;")
+
+    @generate.register
+    def _(self, expr: behav.Assignment, writer):
+        self.generate(expr.target, writer)
+        writer.write(" = ")
+        self.generate(expr.expr, writer)
+
+    @generate.register
+    def _(self, expr: behav.Conditional, writer):
+        for i, stmt in enumerate(expr.stmts):
+            if i == 0:
+                writer.write("if (")
+                self.generate(expr.conds[i], writer)
+                writer.write(")")
+            elif 0 < i < len(expr.conds):
+                writer.write("else if(")
+                self.generate(expr.conds[i], writer)
+                writer.write(")")
+            else:
+                writer.write("else")
+            writer.enter_block()
+            self.generate(stmt, writer)
+            if not isinstance(stmt, (behav.Conditional, behav.Operation)):
+                writer.write_line(";")
+            nl = len(expr.stmts) > i
+            writer.leave_block(nl=nl)
+
+    @generate.register
+    def _(self, expr: behav.Loop, writer):
+        writer.write("while (")
+        self.generate(expr.cond, writer)
+        writer.write(")")
         writer.enter_block()
-    for stmt in self.statements:
-        stmt.generate(writer)
-        if not isinstance(stmt, (behav.Conditional, behav.Operation)):
-            writer.write_line(";")
-    if len(self.statements) > 1:
+        for stmt in expr.stmts:
+            self.generate(stmt, writer)
         writer.leave_block()
 
+    @generate.register
+    def _(self, expr: behav.Ternary, writer):
+        self.generate(expr.cond, writer)
+        writer.write(" ? ")
+        self.generate(expr.then_expr, writer)
+        writer.write(" : ")
+        self.generate(expr.else_expr, writer)
 
-def binary_operation(self: behav.BinaryOperation, writer):
-    self.left = self.left.generate(writer)
-    writer.write(f" {self.op.value} ")
-    self.right = self.right.generate(writer)
+    @generate.register
+    def _(self, expr: behav.Return, writer):
+        writer.write("return")
+        if expr.expr is not None:
+            writer.write(" ")
+            self.generate(expr.expr, writer)
 
+    @generate.register
+    def _(self, expr: behav.UnaryOperation, writer):
+        writer.write(expr.op.value)
+        self.generate(expr.right, writer)
 
-def slice_operation(self: behav.SliceOperation, writer):
-    self.expr = self.expr.generate(writer)
-    writer.write("[")
-    self.left = self.left.generate(writer)
-    writer.write(":")
-    self.right = self.right.generate(writer)
-    writer.write("]")
+    @generate.register
+    def _(self, expr: behav.NamedReference, writer):
+        writer.write(expr.reference.name)
+        if isinstance(expr.reference, (arch.Constant, arch.Memory, arch.Scalar)):
+            pass
 
+    @generate.register
+    def _(self, expr: behav.IndexedReference, writer):
+        writer.write(expr.reference.name)
+        writer.write("[")
+        self.generate(expr.index, writer)
+        writer.write("]")
 
-def concat_operation(self: behav.ConcatOperation, writer):
-    self.left = self.left.generate(writer)
-    writer.write(" :: ")
-    self.right = self.right.generate(writer)
+    @generate.register
+    def _(self, expr: behav.TypeConv, writer):
+        writer.write("(")
+        writer.write_type(expr.data_type, expr.size)
+        writer.write(")")
+        writer.write("(")
+        self.generate(expr.expr, writer)
+        writer.write(")")
 
-
-def number_literal(self: behav.IntLiteral, writer):
-    writer.write(self.value)
-
-
-def int_literal(self: behav.IntLiteral, writer):
-    writer.write(self.value)
-
-
-def scalar_definition(self: behav.ScalarDefinition, writer):
-    writer.write_type(self.scalar.data_type, self.scalar.size)
-    writer.write(" ")
-    writer.write(self.scalar.name)
-    if self.scalar.value:
-        writer.write(" = ")
-        writer.write(self.scalar.value)
-
-
-def break_(self: behav.Break, writer):
-    writer.write_line("break;")
-
-
-def assignment(self: behav.Assignment, writer):
-    self.target.generate(writer)
-    writer.write(" = ")
-    self.expr.generate(writer)
-
-
-def conditional(self: behav.Conditional, writer):
-    for i, stmt in enumerate(self.stmts):
-        if i == 0:
-            writer.write("if (")
-            self.conds[i].generate(writer)
-            writer.write(")")
-        elif 0 < i < len(self.conds):
-            writer.write("else if(")
-            self.conds[i].generate(writer)
-            writer.write(")")
+    @generate.register
+    def _(self, expr: behav.Callable, writer):
+        ref = expr.ref_or_name
+        if isinstance(ref, arch.Function):
+            writer.write(ref.name)
         else:
-            writer.write("else")
-        writer.enter_block()
-        stmt.generate(writer)
-        if not isinstance(stmt, (behav.Conditional, behav.Operation)):
-            writer.write_line(";")
-        nl = len(self.stmts) > i
-        writer.leave_block(nl=nl)
+            raise NotImplementedError
+        writer.write("(")
+        for i, stmt in enumerate(expr.args):
+            self.generate(stmt, writer)
+            if i < len(expr.args) - 1:
+                writer.write(", ")
+        writer.write(")")
 
-
-def loop(self: behav.Loop, writer):
-    writer.write("while (")
-    self.cond.generate(writer)
-    writer.write(")")
-    writer.enter_block()
-    for stmt in self.stmts:
-        stmt.generate(writer)
-    writer.leave_block()
-
-
-def ternary(self: behav.Ternary, writer):
-    self.cond.generate(writer)
-    writer.write(" ? ")
-    self.then_expr.generate(writer)
-    writer.write(" : ")
-    self.else_expr.generate(writer)
-
-
-def return_(self: behav.Return, writer):
-    writer.write("return")
-    if self.expr is not None:
-        writer.write(" ")
-        self.expr = self.expr.generate(writer)
-
-
-def unary_operation(self: behav.UnaryOperation, writer):
-    writer.write(self.op.value)
-    self.right.generate(writer)
-
-
-def named_reference(self: behav.NamedReference, writer):
-    writer.write(self.reference.name)
-    if isinstance(self.reference, (arch.Constant, arch.Memory, arch.Scalar)):
-        # writer.track(self.reference.name)
-        pass
-    # if isinstance(self.reference, arch.Constant):
-    # 	return behav.IntLiteral(self.reference.value, self.reference.size, self.reference.signed)
-
-    # if isinstance(self.reference, arch.Scalar) and self.reference.value is not None:
-    # 		return behav.IntLiteral(self.reference.value, self.reference.size, self.reference.data_type == arch.DataType.S)
-
-
-def indexed_reference(self: behav.IndexedReference, writer):
-    writer.write(self.reference.name)
-    writer.write("[")
-    self.index.generate(writer)
-    writer.write("]")
-
-
-def type_conv(self: behav.TypeConv, writer):
-    writer.write("(")
-    writer.write_type(self.data_type, self.size)
-    writer.write(")")
-    writer.write("(")
-    self.expr.generate(writer)
-    writer.write(")")
-
-def callable_(self: behav.Callable, writer):
-    ref = self.ref_or_name
-    if isinstance(ref, arch.Function):
-        writer.write(ref.name)
-    else:
-        raise NotImplementedError
-    writer.write("(")
-    for i, stmt in enumerate(self.args):
-        stmt.generate(writer)
-        if i < len(self.args) - 1:
-            writer.write(", ")
-    writer.write(")")
-
-
-def group(self: behav.Group, writer):
-    writer.write("(")
-    self.expr.generate(writer)
-    writer.write(")")
+    @generate.register
+    def _(self, expr: behav.Group, writer):
+        writer.write("(")
+        self.generate(expr.expr, writer)
+        writer.write(")")

--- a/m2isar/backends/isa_manual/writer.py
+++ b/m2isar/backends/isa_manual/writer.py
@@ -18,9 +18,9 @@ from collections import defaultdict
 from mako.template import Template
 
 from .utils import generate_encoding
-from . import visitor
+from .visitor import ISAmanualVisitor
 
-from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch, patch_model
+from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch
 from ...metamodel.utils.expr_preprocessor import (process_attributes,
                                                   process_functions,
                                                   process_instructions)
@@ -158,9 +158,10 @@ class CoreDSL2Writer:
 
     def write_behavior2(self, operation, drop_first=False):
         # Eliminate PC increment
+        visitor = ISAmanualVisitor()
         if drop_first:
             operation.statements = operation.statements[1:]
-        operation.generate(self)
+        visitor.generate(operation, self)
 
     def write_behavior(self, instruction):
         self.write("behavior: ")
@@ -258,8 +259,8 @@ def main():
                         enc_str.append(f"{enc.name}[{enc.range.upper}:{enc.range.lower}]")
 
                 writer = CoreDSL2Writer()
-                patch_model(visitor)
-                writer.write_behavior2(instr_def.operation, drop_first=True)
+                visitor = ISAmanualVisitor()
+                writer.write_behavior2(instr_def.operation, visitor, drop_first=True)
                 behavior_text = writer.text
                 asm_str = None
                 if instr_def.assembly:

--- a/m2isar/backends/viewer/treegen.py
+++ b/m2isar/backends/viewer/treegen.py
@@ -17,14 +17,17 @@ from ...metamodel import behav
 from .utils import TreeGenContext
 from ...metamodel.utils.ExprVisitor import ExprVisitor
 from .utils import TreeGenContext
-
+from functools import singledispatchmethod
 # pylint: disable=unused-argument
 
 
 class TreeGenVisitor(ExprVisitor):
 	"""Visitor to generate a ttk.Treeview representation of a M2-ISA-R model structure."""
+	@singledispatchmethod
+	def generate(self, expr : behav.BaseNode, context=None):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def visit_operation(self, expr: behav.Operation, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Operation"))
 
@@ -33,7 +36,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def visit_block(self, expr: behav.Block, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Block"))
 
@@ -42,7 +45,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def visit_binary_operation(self, expr: behav.BinaryOperation, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Binary Operation"))
 
@@ -58,7 +61,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def visit_slice_operation(self, expr: behav.SliceOperation, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Slice Operation"))
 
@@ -77,7 +80,7 @@ class TreeGenVisitor(ExprVisitor):
 		context.pop()
 
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def concat_operation(self, expr: behav.ConcatOperation, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Concat Operation"))
 
@@ -91,23 +94,23 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def number_literal(self, expr: behav.NumberLiteral, context: "TreeGenContext"):
 		context.tree.insert(context.parent, tk.END, text="Number Literal", values=(expr.value,))
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def int_literal(self, expr: behav.IntLiteral, context: "TreeGenContext"):
 		context.tree.insert(context.parent, tk.END, text="Int Literal", values=(expr.value,))
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def scalar_definition(self, expr: behav.ScalarDefinition, context: "TreeGenContext"):
 		context.tree.insert(context.parent, tk.END, text="Scalar Definition", values=(expr.scalar.name,))
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def break_(self, expr: behav.Break, context: "TreeGenContext"):
 		context.tree.insert(context.parent, tk.END, text="Break")
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def assignment(self, expr: behav.Assignment, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Assignment"))
 
@@ -121,7 +124,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def conditional(self, expr: behav.Conditional, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Conditional"))
 
@@ -137,7 +140,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def loop(self, expr: behav.Loop, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Loop"))
 
@@ -154,7 +157,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def ternary(self, expr: behav.Ternary, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Ternary"))
 
@@ -172,7 +175,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def return_(self, expr: behav.Return, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Return"))
 
@@ -183,7 +186,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def unary_operation(self, expr: behav.UnaryOperation, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Unary Operation"))
 
@@ -195,11 +198,11 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def named_reference(self, expr: behav.NamedReference, context: "TreeGenContext"):
 		context.tree.insert(context.parent, tk.END, text="Named Reference", values=(f"{expr.reference}",))
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def indexed_reference(self, expr: behav.IndexedReference, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Indexed Reference"))
 
@@ -211,7 +214,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def type_conv(self, expr: behav.TypeConv, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Type Conv"))
 
@@ -224,7 +227,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def callable_(self, expr: behav.Callable, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Callable", values=(expr.ref_or_name.name,)))
 
@@ -235,7 +238,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def procedure_call(self, expr: behav.ProcedureCall, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="ProcedureCall", values=(expr.ref_or_name.name,)))
 
@@ -246,7 +249,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.pop()
 
-	@ExprVisitor.generate.register
+	@generate.register
 	def group(self, expr: behav.Group, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Group"))
 

--- a/m2isar/backends/viewer/treegen.py
+++ b/m2isar/backends/viewer/treegen.py
@@ -29,7 +29,7 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Operation"))
 
 		for stmt in expr.statements:
-			stmt.generate(context)
+			self.generate(stmt, context)
 
 		context.pop()
 
@@ -38,7 +38,7 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Block"))
 
 		for stmt in expr.statements:
-			stmt.generate(context)
+			self.generate(stmt, context)
 
 		context.pop()
 
@@ -47,11 +47,11 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Binary Operation"))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Left"))
-		expr.left.generate(context)
+		self.generate(expr.left, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-		expr.right.generate(context)
+		self.generate(expr.right, context)
 		context.pop()
 
 		context.tree.insert(context.parent, tk.END, text="Op", values=(expr.op.value,))
@@ -63,32 +63,30 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Slice Operation"))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-		expr.expr.generate(context)
+		self.generate(expr.expr, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Left"))
-		expr.left.generate(context)
+		self.generate(expr.left, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-		expr.right.generate(context)
+		self.generate(expr.right, context)
 		context.pop()
 
 		context.pop()
 
-
-		context.pop()
 
 	@ExprVisitor.generate.register
 	def concat_operation(self, expr: behav.ConcatOperation, context: "TreeGenContext"):
 		context.push(context.tree.insert(context.parent, tk.END, text="Concat Operation"))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Left"))
-		expr.left.generate(context)
+		self.generate(expr.left, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-		expr.right.generate(context)
+		self.generate(expr.right, context)
 		context.pop()
 
 		context.pop()
@@ -114,11 +112,11 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Assignment"))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Target"))
-		expr.target.generate(context)
+		self.generate(expr.target, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-		expr.expr.generate(context)
+		self.generate(expr.expr, context)
 		context.pop()
 
 		context.pop()
@@ -129,12 +127,12 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Conditions"))
 		for cond in expr.conds:
-			cond.generate(context)
+			self.generate(cond, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Statements"))
 		for stmt in expr.stmts:
-			stmt.generate(context)
+			self.generate(stmt, context)
 		context.pop()
 
 		context.pop()
@@ -146,12 +144,12 @@ class TreeGenVisitor(ExprVisitor):
 		context.tree.insert(context.parent, tk.END, text="Post Test", values=(expr.post_test,))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Condition"))
-		expr.cond.generate(context)
+		self.generate(expr.cond, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Statements"))
 		for stmt in expr.stmts:
-			stmt.generate(context)
+			self.generate(stmt, context)
 		context.pop()
 
 		context.pop()
@@ -161,15 +159,15 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Ternary"))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Cond"))
-		expr.cond.generate(context)
+		self.generate(expr.cond, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Then Expression"))
-		expr.then_expr.generate(context)
+		self.generate(expr.then_expr, context)
 		context.pop()
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Else Expression"))
-		expr.else_expr.generate(context)
+		self.generate(expr.else_expr, context)
 		context.pop()
 
 		context.pop()
@@ -180,7 +178,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		if expr.expr is not None:
 			context.push(context.tree.insert(context.parent, tk.END, text="Expression"))
-			expr.expr.generate(context)
+			self.generate(expr.expr, context)
 			context.pop()
 
 		context.pop()
@@ -190,7 +188,7 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Unary Operation"))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-		expr.right.generate(context)
+		self.generate(expr.right, context)
 		context.pop()
 
 		context.tree.insert(context.parent, tk.END, text="Op", values=(expr.op.value,))
@@ -208,7 +206,7 @@ class TreeGenVisitor(ExprVisitor):
 		context.tree.insert(context.parent, tk.END, text="Reference", values=(f"{expr.reference}",))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Index"))
-		expr.index.generate(context)
+		self.generate(expr.index, context)
 		context.pop()
 
 		context.pop()
@@ -221,7 +219,7 @@ class TreeGenVisitor(ExprVisitor):
 		context.tree.insert(context.parent, tk.END, text="Size", values=(expr.size,))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-		expr.expr.generate(context)
+		self.generate(expr.expr, context)
 		context.pop()
 
 		context.pop()
@@ -232,7 +230,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		for arg, arg_descr in zip(expr.args, expr.ref_or_name.args):
 			context.push(context.tree.insert(context.parent, tk.END, text="Arg", values=(arg_descr,)))
-			arg.generate(context)
+			self.generate(arg, context)
 			context.pop()
 
 		context.pop()
@@ -243,7 +241,7 @@ class TreeGenVisitor(ExprVisitor):
 
 		for arg, arg_descr in zip(expr.args, expr.ref_or_name.args):
 			context.push(context.tree.insert(context.parent, tk.END, text="Arg", values=(arg_descr,)))
-			arg.generate(context)
+			self.generate(arg, context)
 			context.pop()
 
 		context.pop()
@@ -253,7 +251,7 @@ class TreeGenVisitor(ExprVisitor):
 		context.push(context.tree.insert(context.parent, tk.END, text="Group"))
 
 		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-		expr.expr.generate(context)
+		self.generate(expr.expr, context)
 		context.pop()
 
 		context.pop()

--- a/m2isar/backends/viewer/treegen.py
+++ b/m2isar/backends/viewer/treegen.py
@@ -5,6 +5,9 @@
 # Copyright (C) 2022
 # Chair of Electrical Design Automation
 # Technical University of Munich
+#
+# Copyright (C) 2026
+# Modifed by JK TUW ECS
 
 """Generate a ttk.Treeview representation of a M2-ISA-R model structure."""
 
@@ -12,215 +15,245 @@ import tkinter as tk
 
 from ...metamodel import behav
 from .utils import TreeGenContext
+from ...metamodel.utils.ExprVisitor import ExprVisitor
+from .utils import TreeGenContext
 
 # pylint: disable=unused-argument
 
-def operation(self: behav.Operation, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Operation"))
 
-	for stmt in self.statements:
-		stmt.generate(context)
+class TreeGenVisitor(ExprVisitor):
+	"""Visitor to generate a ttk.Treeview representation of a M2-ISA-R model structure."""
 
-	context.pop()
+	@ExprVisitor.generate.register
+	def visit_operation(self, expr: behav.Operation, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Operation"))
 
-def block(self: behav.Block, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Block"))
+		for stmt in expr.statements:
+			stmt.generate(context)
 
-	for stmt in self.statements:
-		stmt.generate(context)
-
-	context.pop()
-
-def binary_operation(self: behav.BinaryOperation, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Binary Operation"))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Left"))
-	self.left.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-	self.right.generate(context)
-	context.pop()
-
-	context.tree.insert(context.parent, tk.END, text="Op", values=(self.op.value,))
-
-	context.pop()
-
-def slice_operation(self: behav.SliceOperation, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Slice Operation"))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-	self.expr.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Left"))
-	self.left.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-	self.right.generate(context)
-	context.pop()
-
-	context.pop()
-
-def concat_operation(self: behav.ConcatOperation, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Concat Operation"))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Left"))
-	self.left.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-	self.right.generate(context)
-	context.pop()
-
-	context.pop()
-
-def number_literal(self: behav.NumberLiteral, context: "TreeGenContext"):
-	context.tree.insert(context.parent, tk.END, text="Number Literal", values=(self.value,))
-
-def int_literal(self: behav.IntLiteral, context: "TreeGenContext"):
-	context.tree.insert(context.parent, tk.END, text="Int Literal", values=(self.value,))
-
-def scalar_definition(self: behav.ScalarDefinition, context: "TreeGenContext"):
-	context.tree.insert(context.parent, tk.END, text="Scalar Definition", values=(self.scalar.name,))
-
-def break_(self: behav.Break, context: "TreeGenContext"):
-	context.tree.insert(context.parent, tk.END, text="Break")
-
-def assignment(self: behav.Assignment, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Assignment"))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Target"))
-	self.target.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-	self.expr.generate(context)
-	context.pop()
-
-	context.pop()
-
-def conditional(self: behav.Conditional, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Conditional"))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Conditions"))
-	for cond in self.conds:
-		cond.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Statements"))
-	for stmt in self.stmts:
-		stmt.generate(context)
-	context.pop()
-
-	context.pop()
-
-def loop(self: behav.Loop, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Loop"))
-
-	context.tree.insert(context.parent, tk.END, text="Post Test", values=(self.post_test,))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Condition"))
-	self.cond.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Statements"))
-	for stmt in self.stmts:
-		stmt.generate(context)
-	context.pop()
-
-	context.pop()
-
-def ternary(self: behav.Ternary, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Ternary"))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Cond"))
-	self.cond.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Then Expression"))
-	self.then_expr.generate(context)
-	context.pop()
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Else Expression"))
-	self.else_expr.generate(context)
-	context.pop()
-
-	context.pop()
-
-def return_(self: behav.Return, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Return"))
-
-	if self.expr is not None:
-		context.push(context.tree.insert(context.parent, tk.END, text="Expression"))
-		self.expr.generate(context)
 		context.pop()
 
-	context.pop()
+	@ExprVisitor.generate.register
+	def visit_block(self, expr: behav.Block, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Block"))
 
-def unary_operation(self: behav.UnaryOperation, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Unary Operation"))
+		for stmt in expr.statements:
+			stmt.generate(context)
 
-	context.push(context.tree.insert(context.parent, tk.END, text="Right"))
-	self.right.generate(context)
-	context.pop()
-
-	context.tree.insert(context.parent, tk.END, text="Op", values=(self.op.value,))
-
-	context.pop()
-
-def named_reference(self: behav.NamedReference, context: "TreeGenContext"):
-	context.tree.insert(context.parent, tk.END, text="Named Reference", values=(f"{self.reference}",))
-
-def indexed_reference(self: behav.IndexedReference, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Indexed Reference"))
-
-	context.tree.insert(context.parent, tk.END, text="Reference", values=(f"{self.reference}",))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Index"))
-	self.index.generate(context)
-	context.pop()
-
-	context.pop()
-
-def type_conv(self: behav.TypeConv, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Type Conv"))
-
-	context.tree.insert(context.parent, tk.END, text="Type", values=(self.data_type,))
-	context.tree.insert(context.parent, tk.END, text="Size", values=(self.size,))
-
-	context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-	self.expr.generate(context)
-	context.pop()
-
-	context.pop()
-
-def callable_(self: behav.Callable, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Callable", values=(self.ref_or_name.name,)))
-
-	for arg, arg_descr in zip(self.args, self.ref_or_name.args):
-		context.push(context.tree.insert(context.parent, tk.END, text="Arg", values=(arg_descr,)))
-		arg.generate(context)
 		context.pop()
 
-	context.pop()
+	@ExprVisitor.generate.register
+	def visit_binary_operation(self, expr: behav.BinaryOperation, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Binary Operation"))
 
-def procedure_call(self: behav.ProcedureCall, context: TransformerContext):
-	context.push(context.tree.insert(context.parent, tk.END, text="ProcedureCall", values=(self.ref_or_name.name,)))
-
-	for arg, arg_descr in zip(self.args, self.ref_or_name.args):
-		context.push(context.tree.insert(context.parent, tk.END, text="Arg", values=(arg_descr,)))
-		arg.generate(context)
+		context.push(context.tree.insert(context.parent, tk.END, text="Left"))
+		expr.left.generate(context)
 		context.pop()
 
-	context.pop()
+		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
+		expr.right.generate(context)
+		context.pop()
 
-def group(self: behav.Group, context: "TreeGenContext"):
-	context.push(context.tree.insert(context.parent, tk.END, text="Group"))
+		context.tree.insert(context.parent, tk.END, text="Op", values=(expr.op.value,))
 
-	context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
-	self.expr.generate(context)
-	context.pop()
+		context.pop()
 
-	context.pop()
+	@ExprVisitor.generate.register
+	def visit_slice_operation(self, expr: behav.SliceOperation, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Slice Operation"))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
+		expr.expr.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Left"))
+		expr.left.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
+		expr.right.generate(context)
+		context.pop()
+
+		context.pop()
+
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def concat_operation(self, expr: behav.ConcatOperation, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Concat Operation"))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Left"))
+		expr.left.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
+		expr.right.generate(context)
+		context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def number_literal(self, expr: behav.NumberLiteral, context: "TreeGenContext"):
+		context.tree.insert(context.parent, tk.END, text="Number Literal", values=(expr.value,))
+
+	@ExprVisitor.generate.register
+	def int_literal(self, expr: behav.IntLiteral, context: "TreeGenContext"):
+		context.tree.insert(context.parent, tk.END, text="Int Literal", values=(expr.value,))
+
+	@ExprVisitor.generate.register
+	def scalar_definition(self, expr: behav.ScalarDefinition, context: "TreeGenContext"):
+		context.tree.insert(context.parent, tk.END, text="Scalar Definition", values=(expr.scalar.name,))
+
+	@ExprVisitor.generate.register
+	def break_(self, expr: behav.Break, context: "TreeGenContext"):
+		context.tree.insert(context.parent, tk.END, text="Break")
+
+	@ExprVisitor.generate.register
+	def assignment(self, expr: behav.Assignment, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Assignment"))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Target"))
+		expr.target.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
+		expr.expr.generate(context)
+		context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def conditional(self, expr: behav.Conditional, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Conditional"))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Conditions"))
+		for cond in expr.conds:
+			cond.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Statements"))
+		for stmt in expr.stmts:
+			stmt.generate(context)
+		context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def loop(self, expr: behav.Loop, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Loop"))
+
+		context.tree.insert(context.parent, tk.END, text="Post Test", values=(expr.post_test,))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Condition"))
+		expr.cond.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Statements"))
+		for stmt in expr.stmts:
+			stmt.generate(context)
+		context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def ternary(self, expr: behav.Ternary, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Ternary"))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Cond"))
+		expr.cond.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Then Expression"))
+		expr.then_expr.generate(context)
+		context.pop()
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Else Expression"))
+		expr.else_expr.generate(context)
+		context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def return_(self, expr: behav.Return, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Return"))
+
+		if expr.expr is not None:
+			context.push(context.tree.insert(context.parent, tk.END, text="Expression"))
+			expr.expr.generate(context)
+			context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def unary_operation(self, expr: behav.UnaryOperation, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Unary Operation"))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Right"))
+		expr.right.generate(context)
+		context.pop()
+
+		context.tree.insert(context.parent, tk.END, text="Op", values=(expr.op.value,))
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def named_reference(self, expr: behav.NamedReference, context: "TreeGenContext"):
+		context.tree.insert(context.parent, tk.END, text="Named Reference", values=(f"{expr.reference}",))
+
+	@ExprVisitor.generate.register
+	def indexed_reference(self, expr: behav.IndexedReference, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Indexed Reference"))
+
+		context.tree.insert(context.parent, tk.END, text="Reference", values=(f"{expr.reference}",))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Index"))
+		expr.index.generate(context)
+		context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def type_conv(self, expr: behav.TypeConv, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Type Conv"))
+
+		context.tree.insert(context.parent, tk.END, text="Type", values=(expr.data_type,))
+		context.tree.insert(context.parent, tk.END, text="Size", values=(expr.size,))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
+		expr.expr.generate(context)
+		context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def callable_(self, expr: behav.Callable, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Callable", values=(expr.ref_or_name.name,)))
+
+		for arg, arg_descr in zip(expr.args, expr.ref_or_name.args):
+			context.push(context.tree.insert(context.parent, tk.END, text="Arg", values=(arg_descr,)))
+			arg.generate(context)
+			context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def procedure_call(self, expr: behav.ProcedureCall, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="ProcedureCall", values=(expr.ref_or_name.name,)))
+
+		for arg, arg_descr in zip(expr.args, expr.ref_or_name.args):
+			context.push(context.tree.insert(context.parent, tk.END, text="Arg", values=(arg_descr,)))
+			arg.generate(context)
+			context.pop()
+
+		context.pop()
+
+	@ExprVisitor.generate.register
+	def group(self, expr: behav.Group, context: "TreeGenContext"):
+		context.push(context.tree.insert(context.parent, tk.END, text="Group"))
+
+		context.push(context.tree.insert(context.parent, tk.END, text="Expr"))
+		expr.expr.generate(context)
+		context.pop()
+
+		context.pop()

--- a/m2isar/backends/viewer/viewer.py
+++ b/m2isar/backends/viewer/viewer.py
@@ -5,6 +5,9 @@
 # Copyright (C) 2022
 # Chair of Electrical Design Automation
 # Technical University of Munich
+#
+# Copyright (C) 2026
+# Modifed by JK TUW ECS
 
 """Viewer tool to visualize an M2-ISA-R model hierarchy."""
 
@@ -22,7 +25,7 @@ from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch, patch_model
 from ...metamodel.utils.expr_preprocessor import (process_attributes,
                                                   process_functions,
                                                   process_instructions)
-from . import treegen
+from .treegen import TreeGenVisitor
 
 logger = logging.getLogger("viewer")
 
@@ -83,7 +86,7 @@ def main():
 		process_attributes(core)
 
 	# load Ttk TreeView transformer functions
-	patch_model(treegen)
+	visitor = TreeGenVisitor()
 
 	# create main Tk window
 	root = tk.Tk()
@@ -141,7 +144,7 @@ def main():
 				attr_id = tree.insert(attrs_id, tk.END, text=attr)
 				for op in ops:
 					context = TreeGenContext(tree, attr_id)
-					op.generate(context)
+					visitor.generate(op, context)
 
 			# generate and add parameters
 			params_id = tree.insert(fn_id, tk.END, text="Parameters")
@@ -151,7 +154,7 @@ def main():
 
 			# generate and add function behavior
 			context = TreeGenContext(tree, fn_id)
-			fn_def.operation.generate(context)
+			visitor.generate(fn_def.operation, context)
 
 		# group instructions by size
 		instrs_by_size = defaultdict(dict)
@@ -193,11 +196,13 @@ def main():
 					attr_id = tree.insert(attrs_id, tk.END, text=attr.name)
 					for op in ops:
 						context = TreeGenContext(tree, attr_id)
-						op.generate(context)
+						visitor.generate(op, context)
 
 				# generate behavior
 				context = TreeGenContext(tree, instr_id)
-				instr_def.operation.generate(context)
+				visitor.generate(instr_def.operation, context)
+
+
 
 	#tree.tag_configure("mono", font=font.nametofont("TkFixedFont"))
 

--- a/m2isar/backends/viewer/viewer.py
+++ b/m2isar/backends/viewer/viewer.py
@@ -21,7 +21,7 @@ from tkinter import ttk
 
 from m2isar.backends.viewer.utils import TreeGenContext
 
-from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch, patch_model
+from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch
 from ...metamodel.utils.expr_preprocessor import (process_attributes,
                                                   process_functions,
                                                   process_instructions)

--- a/m2isar/frontends/coredsl2/architecture_model_builder.py
+++ b/m2isar/frontends/coredsl2/architecture_model_builder.py
@@ -16,9 +16,10 @@ from ...metamodel import arch, behav, intrinsics
 from ...metamodel.code_info import FunctionInfoFactory
 from .parser_gen import CoreDSL2Parser, CoreDSL2Visitor
 from .utils import RADIX, SHORTHANDS, SIGNEDNESS
+from .expr_interpreter import ExprInterpreterVisitor
 
 logger = logging.getLogger("arch_builder")
-
+exprInterpretVisitor = ExprInterpreterVisitor()
 
 class ArchitectureModelBuilder(CoreDSL2Visitor):
 	"""ANTLR visitor to build an M2-ISA-R architecture model of a CoreDSL 2 specification."""
@@ -379,7 +380,7 @@ class ArchitectureModelBuilder(CoreDSL2Visitor):
 
 					# attach init value to memory object
 					if init is not None:
-						m._initval[None] = init.generate(None)
+						m._initval[None] = exprInterpretVisitor.generate(init, None)
 
 					if arch.MemoryAttribute.IS_MAIN_REG in attributes:
 						self._main_reg_file = m
@@ -490,13 +491,13 @@ class ArchitectureModelBuilder(CoreDSL2Visitor):
 		# if LHS is a reference, assign RHS as its default value
 		if isinstance(left, behav.NamedReference):
 			if isinstance(left.reference, arch.Constant):
-				left.reference.value = right.generate(None)
+				left.reference.value = exprInterpretVisitor.generate(right, None)
 
 			elif isinstance(left.reference, arch.Memory):
-				left.reference._initval[None] = right.generate(None)
+				left.reference._initval[None] = exprInterpretVisitor.generate(right, None)
 
 		elif isinstance(left, behav.IndexedReference):
-			left.reference._initval[left.index.generate(None)] = right.generate(None)
+			left.reference._initval[exprInterpretVisitor.generate(left.index, None)] = exprInterpretVisitor.generate(right, None)
 
 	def visitAttribute(self, ctx: CoreDSL2Parser.AttributeContext):
 		"""Generate an attribute."""

--- a/m2isar/frontends/coredsl2/behavior_model_builder.py
+++ b/m2isar/frontends/coredsl2/behavior_model_builder.py
@@ -18,6 +18,9 @@ from ...metamodel.code_info import (BranchEntryInfoFactory, BranchInfo,
 from ...metamodel.utils import StaticType
 from .parser_gen import CoreDSL2Parser, CoreDSL2Visitor
 from .utils import BOOLCONST, RADIX, SHORTHANDS, SIGNEDNESS
+from .expr_interpreter import ExprInterpreterVisitor
+
+exprInterpretVisitor = ExprInterpreterVisitor()
 
 if TYPE_CHECKING:
 	from ...metamodel.code_info import LineInfo
@@ -411,7 +414,7 @@ class BehaviorModelBuilder(CoreDSL2Visitor):
 			width = self.visit(ctx.shorthand)
 
 		if isinstance(width, behav.BaseNode):
-			width = width.generate(None)
+			width =  exprInterpretVisitor.generate(width, None)
 		else:
 			raise M2TypeError("width has wrong type")
 

--- a/m2isar/frontends/coredsl2/expr_interpreter.py
+++ b/m2isar/frontends/coredsl2/expr_interpreter.py
@@ -10,28 +10,47 @@
 
 from ... import M2ValueError
 from ...metamodel import arch, behav
+from ...metamodel.utils.ExprVisitor import ExprVisitor
+from functools import singledispatchmethod
 
 
-def group(self: behav.Group, context):
-	return self.expr.generate(context)
+class ExprInterpreterVisitor(ExprVisitor):
+	"""Visitor for evaluating parse-time constant expressions."""
 
-def int_literal(self: behav.IntLiteral, context):
-	return self.value
+	@singledispatchmethod
+	def generate(self, expr: behav.BaseNode, context=None):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(self).__name__}")
 
-def named_reference(self: behav.NamedReference, context):
-	if isinstance(self.reference, arch.Constant) and self.reference.value is not None:
-		return self.reference.value
-	raise M2ValueError("non-interpretable value encountered")
+	@generate.register
+	def _(self, expr: behav.Group, context):
+		return self.generate(expr.expr, context)
 
-def indexed_reference(self: behav.IndexedReference, context):
-	idx = self.index.generate(context)
-	return self.reference._initval[idx]
+	@generate.register
+	def _(self, expr: behav.NumberLiteral, context):
+		return expr.value
 
-def binary_operation(self: behav.BinaryOperation, context):
-	left = self.left.generate(context)
-	right = self.right.generate(context)
-	return int(eval(f"{left}{self.op.value}{right}"))
+	@generate.register
+	def _(self, expr: behav.IntLiteral, context):
+		return expr.value
 
-def unary_operation(self: behav.UnaryOperation, context):
-	right = self.right.generate(context)
-	return int(eval(f"{self.op.value}{right}"))
+	@generate.register
+	def _(self, expr: behav.NamedReference, context):
+		if isinstance(expr.reference, arch.Constant) and expr.reference.value is not None:
+			return expr.reference.value
+		raise M2ValueError("non-interpretable value encountered")
+
+	@generate.register
+	def _(self, expr: behav.IndexedReference, context):
+		idx = self.generate(expr.index, context)
+		return expr.reference._initval[idx]
+
+	@generate.register
+	def _(self, expr: behav.BinaryOperation, context):
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
+		return int(eval(f"{left}{expr.op.value}{right}"))
+
+	@generate.register
+	def _(self, expr: behav.UnaryOperation, context):
+		right = self.generate(expr.right, context)
+		return int(eval(f"{expr.op.value}{right}"))

--- a/m2isar/frontends/coredsl2/parser.py
+++ b/m2isar/frontends/coredsl2/parser.py
@@ -14,10 +14,8 @@ import pickle
 import sys
 
 from ... import M2Error, M2SyntaxError
-from ...metamodel import (M2_METAMODEL_VERSION, M2Model, arch, behav,
-                          patch_model)
+from ...metamodel import M2_METAMODEL_VERSION, M2Model, arch, behav
 from ...metamodel.code_info import CodeInfoBase
-from . import expr_interpreter
 from .architecture_model_builder import ArchitectureModelBuilder
 from .behavior_model_builder import BehaviorModelBuilder
 from .importer import recursive_import
@@ -66,8 +64,6 @@ def main():
 
 	temp_save = {}
 	models: "dict[str, arch.CoreDef]" = {}
-
-	patch_model(expr_interpreter)
 
 	for core_name, core_def in cores.items():
 		logger.info('building architecture model for core %s', core_name)

--- a/m2isar/metamodel/__init__.py
+++ b/m2isar/metamodel/__init__.py
@@ -13,15 +13,17 @@ description.
 Also included are preprocessing functions, mostly to simplify a model and to extract information
 about scalar and function staticness as well as exceptions.
 
-Any model traversal should use the :func:`patch_model` function and a module including the needed
-transformations. :func:`patch_model` monkey patches transformation functions into the classes of the
-behavior model, therefore separating model code from transformation code. For examples on how
-these transformation functions look like, see either the modules in :mod:`m2isar.metamodel.utils`
-or the main code generation module :mod:`m2isar.backends.etiss.instruction_transform`. For a description
-of the monkey patching, see :func:`patch_model`.
+Any model traversal should use a :subclass`` of the ExprVisitor MetaClass including the needed
+transformations/ recursive calls. For examples on how the recursive generate functions look like,
+see the ExprVisitor MetaClass with its default generate function in :mod:`m2isar.metamodel.utils.ExprVisitor`
+Multiple examples of such visitors can be found in the :mod:`m2isar.backends` submodules,
+e.g. :mod:`m2isar.backends.etiss.instruction_transform` or :mod:`m2isar.backends.isa_manual.visitor`.
+But also the metamodel builders in :mod:`m2isar.frontends.coredsl2` use this approach to build
+the model from the parse tree. As well as the Frontend.
 
 Usually a M2-ISA-R behavioral model is traversed from top to bottom. Necessary contextual
-information is passed to lower levels by a user-defined `context` object. Each object should then
+information is either stored globally within the self object of the ExprVisitor or passed to lower levels
+by a user-defined `context` object for local stack-based information. Each object should then
 generate a piece of output (e.g. c-code for ETISS) and return it to its parent. Value passing between
 generation functions is completely user-defined, :mod:`m2isar.backends.etiss.instruction_transform`
 uses complex objects in lower levels of translation and switches to strings for the two highest levels of

--- a/m2isar/metamodel/arch.py
+++ b/m2isar/metamodel/arch.py
@@ -16,20 +16,21 @@ import itertools
 from collections import defaultdict
 from enum import Enum, IntEnum, auto
 from typing import TYPE_CHECKING, Any, Union
+from m2isar.frontends.coredsl2.expr_interpreter import ExprInterpreterVisitor
 
 from .. import M2TypeError
 from .behav import BaseNode, Operation
 
 if TYPE_CHECKING:
 	from .code_info import FunctionInfo
-
+exprInterpretVisitor = ExprInterpreterVisitor()
 
 def get_const_or_val(arg) -> int:
 	if isinstance(arg, Constant):
 		return arg.value
 
 	if isinstance(arg, BaseNode):
-		return arg.generate(None)
+		return exprInterpretVisitor.generate(arg, None)
 
 	return arg
 

--- a/m2isar/metamodel/behav.py
+++ b/m2isar/metamodel/behav.py
@@ -6,7 +6,10 @@
 # Chair of Electrical Design Automation
 # Technical University of Munich
 
-"""This module contains classes for modeling the behavioral part
+""" Deprecated module, only used for legacy reasons. Monkey patching can be avoided
+by a custom ExprVisitor subclass and a custom generate function.
+See :mod:`m2isar.metamodel.utils.ExprVisitor` for more details on how to do this.
+This module contains classes for modeling the behavioral part
 of an M2-ISA-R model, this means the functional behavior of functions
 and instructions. Behavior is modeled as a tree of instances of the classes
 in this module. This object tree can then be traversed with transformation

--- a/m2isar/metamodel/utils/ExprVisitor.py
+++ b/m2isar/metamodel/utils/ExprVisitor.py
@@ -12,7 +12,6 @@ functions and instructions to get rid of monkey patching and use instead polymor
 
 from ...metamodel import behav
 from abc import ABC, abstractmethod
-
 from functools import singledispatchmethod
 # pylint: disable=unused-argument
 
@@ -25,107 +24,111 @@ class ExprVisitor(ABC):
     Use self for additonal global state information
     Use context for stack-based information that is only relevant for the current branch of the AST.
     """
-    @singledispatchmethod
+    @abstractmethod
     def generate(self, expr : behav.BaseNode, context=None):
         raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
 
-    @generate.register
+    @singledispatchmethod
+    def default_visit(self, expr: behav.BaseNode, context):
+        raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
+
+    @default_visit.register
     def visit_codeliteral(self, expr: behav.CodeLiteral, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_operator(self, expr: behav.Operator, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_operation(self, expr: behav.Operation, context):
         for stmt in expr.statements:
             stmt.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_block(self, expr: behav.Block, context):
         for stmt in expr.statements:
             stmt.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_binary_operation(self, expr: behav.BinaryOperation, context):
         expr.left.generate(context)
         expr.right.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_slice_operation(self, expr: behav.SliceOperation, context):
         expr.expr.generate(context)
         expr.left.generate(context)
         expr.right.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_concat_operation(self, expr: behav.ConcatOperation, context):
         expr.left.generate(context)
         expr.right.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_number_literal(self, expr: behav.NumberLiteral, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_int_literal(self, expr: behav.IntLiteral, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_string_literal(self, expr: behav.StringLiteral, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_assignment(self, expr: behav.Assignment, context):
         expr.target.generate(context)
         expr.expr.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_conditional(self, expr: behav.Conditional, context):
         for cond in expr.conds:
             cond.generate(context)
         for stmt in expr.stmts:
             stmt.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_loop(self, expr: behav.Loop, context):
         expr.cond.generate(context)
         for stmt in expr.stmts:
             stmt.generate(context)
 
     # TODO: Add more visit methods for other node types as needed, e.g., Ternary, etc.
-    @generate.register
+    @default_visit.register
     def visit_ternary_operation(self, expr: behav.Ternary, context):
         expr.cond.generate(context)
         expr.then_expr.generate(context)
         expr.else_expr.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_scalar_definition(self, expr: behav.ScalarDefinition, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_break(self, expr: behav.Break, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_named_reference(self, expr: behav.NamedReference, context):
         pass
 
-    @generate.register
+    @default_visit.register
     def visit_type_conv(self, expr: behav.TypeConv, context):
         expr.expr.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_callable(self, expr: behav.Callable, context):
         for arg in expr.args:
             arg.generate(context)
 
-    @generate.register
+    @default_visit.register
     def visit_procedure_call(self, expr: behav.Callable, context):
         for arg in expr.args:
             arg.generate(context)
 
-    @generate.register
-    def group(self, expr: behav.Group, context):
+    @default_visit.register
+    def visit_group(self, expr: behav.Group, context):
         expr.expr.generate(context)

--- a/m2isar/metamodel/utils/ExprVisitor.py
+++ b/m2isar/metamodel/utils/ExprVisitor.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of the M2-ISA-R project: https://github.com/tum-ei-eda/M2-ISA-R
+#
+# Copyright (C) 2026
+# Chair of Embedded Computing Systems
+# Technical University of Wien
+
+"""A helper module for applying all expression visitor functions in this package to
+functions and instructions to get rid of monkey patching and use instead polymorphism.
+"""
+
+from ...metamodel import behav
+from abc import ABC, abstractmethod
+
+from functools import singledispatchmethod
+# pylint: disable=unused-argument
+
+
+class ExprVisitor(ABC):
+    """Base class for recursive metamodel traversal with 2 modes:
+        - Generating text by appending context while traversing AST.
+        - Analyzing/Mutating the AST (sometimes with the help of a context) and returning a modified AST.
+    To implement a new visitor, overload the 'generate' method of nodes that need altered visitation behavior.
+    """
+    @singledispatchmethod
+    def generate(self, expr : behav.BaseNode, context=None):
+        raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
+
+    @generate.register
+    def visit_codeliteral(self, expr: behav.CodeLiteral, context):
+        pass
+
+    @generate.register
+    def visit_operator(self, expr: behav.Operator, context):
+        pass
+
+    @generate.register
+    def visit_operation(self, expr: behav.Operation, context):
+        for stmt in expr.statements:
+            stmt.generate(context)
+
+    @generate.register
+    def visit_block(self, expr: behav.Block, context):
+        for stmt in expr.statements:
+            stmt.generate(context)
+
+    @generate.register
+    def visit_binary_operation(self, expr: behav.BinaryOperation, context):
+        expr.left.generate(context)
+        expr.right.generate(context)
+
+    @generate.register
+    def visit_slice_operation(self, expr: behav.SliceOperation, context):
+        expr.expr.generate(context)
+        expr.left.generate(context)
+        expr.right.generate(context)
+
+    @generate.register
+    def visit_concat_operation(self, expr: behav.ConcatOperation, context):
+        expr.left.generate(context)
+        expr.right.generate(context)
+
+    @generate.register
+    def visit_number_literal(self, expr: behav.NumberLiteral, context):
+        pass
+
+    @generate.register
+    def visit_int_literal(self, expr: behav.IntLiteral, context):
+        pass
+
+    @generate.register
+    def visit_string_literal(self, expr: behav.StringLiteral, context):
+        pass
+
+    @generate.register
+    def visit_assignment(self, expr: behav.Assignment, context):
+        expr.target.generate(context)
+        expr.expr.generate(context)
+
+    @generate.register
+    def visit_conditional(self, expr: behav.Conditional, context):
+        for cond in expr.conds:
+            cond.generate(context)
+        for stmt in expr.stmts:
+            stmt.generate(context)
+
+    @generate.register
+    def visit_loop(self, expr: behav.Loop, context):
+        expr.cond.generate(context)
+        for stmt in expr.stmts:
+            stmt.generate(context)
+
+    # TODO: Add more visit methods for other node types as needed, e.g., Ternary, etc.
+    @generate.register
+    def visit_ternary_operation(self, expr: behav.Ternary, context):
+        expr.cond.generate(context)
+        expr.then_expr.generate(context)
+        expr.else_expr.generate(context)
+
+    @generate.register
+    def visit_scalar_definition(self, expr: behav.ScalarDefinition, context):
+        pass
+
+    @generate.register
+    def visit_break(self, expr: behav.Break, context):
+        pass
+
+    @generate.register
+    def visit_named_reference(self, expr: behav.NamedReference, context):
+        pass
+
+    @generate.register
+    def visit_type_conv(self, expr: behav.TypeConv, context):
+        expr.expr.generate(context)
+
+    @generate.register
+    def visit_callable(self, expr: behav.Callable, context):
+        for arg in expr.args:
+            arg.generate(context)
+
+    @generate.register
+    def visit_procedure_call(self, expr: behav.Callable, context):
+        for arg in expr.args:
+            arg.generate(context)
+
+    @generate.register
+    def group(self, expr: behav.Group, context):
+        expr.expr.generate(context)

--- a/m2isar/metamodel/utils/ExprVisitor.py
+++ b/m2isar/metamodel/utils/ExprVisitor.py
@@ -22,6 +22,8 @@ class ExprVisitor(ABC):
         - Generating text by appending context while traversing AST.
         - Analyzing/Mutating the AST (sometimes with the help of a context) and returning a modified AST.
     To implement a new visitor, overload the 'generate' method of nodes that need altered visitation behavior.
+    Use self for additonal global state information
+    Use context for stack-based information that is only relevant for the current branch of the AST.
     """
     @singledispatchmethod
     def generate(self, expr : behav.BaseNode, context=None):

--- a/m2isar/metamodel/utils/expr_preprocessor.py
+++ b/m2isar/metamodel/utils/expr_preprocessor.py
@@ -14,42 +14,46 @@ import logging
 from itertools import chain
 
 from ... import M2ValueError
-from .. import arch, patch_model
-from . import (ScalarStaticnessContext, expr_simplifier, function_staticness,
-               function_throws, scalar_staticness)
+from .. import arch
+from . import ScalarStaticnessContext
+from .expr_simplifier import ExprSimplifierVisitor
+from .function_staticness import FunctionStaticnessVisitor
+from .function_throws import FunctionThrowsVisitor
+from .scalar_staticness import ScalarStaticnessVisitor
 
 logger = logging.getLogger("preprocessor")
 
 def process_attributes(core: arch.CoreDef):
 	"""Apply all preprocessing to memory, function and instruction attributes in `core`."""
 
-	patch_model(expr_simplifier)
+	simplifier = ExprSimplifierVisitor()
 
 	for _, obj_def in chain(core.functions.items(), core.instructions.items(), core.memories.items(), core.memory_aliases.items()):
 		for attr_name, attr_defs in obj_def.attributes.items():
 			logger.debug("simplifying expressions for attr %s of %s", attr_name, obj_def.name)
 			for attr_def in attr_defs:
-				attr_def.generate(None)
+				simplifier.generate(attr_def, None)
 
 def process_functions(core: arch.CoreDef):
 	"""Apply all preprocessing to all functions in `core`."""
 
-	for fn_name, fn_def in core.functions.items():
-		patch_model(expr_simplifier)
-		logger.debug("simplifying expressions for fn %s", fn_name)
-		fn_def.operation.generate(None)
+	simplifier = ExprSimplifierVisitor()
+	function_throws_visitor = FunctionThrowsVisitor()
+	scalar_staticness_visitor = ScalarStaticnessVisitor()
+	function_staticness_visitor = FunctionStaticnessVisitor()
 
-		patch_model(function_throws)
+	for fn_name, fn_def in core.functions.items():
+		logger.debug("simplifying expressions for fn %s", fn_name)
+		simplifier.generate(fn_def.operation, None)
+
 		logger.debug("checking throws for fn %s", fn_name)
-		throws = fn_def.operation.generate(None)
+		throws = function_throws_visitor.generate(fn_def.operation, None)
 		fn_def.throws = throws or arch.FunctionAttribute.ETISS_TRAP_ENTRY_FN in fn_def.attributes
 
 		context = ScalarStaticnessContext()
-		patch_model(scalar_staticness)
 		logger.debug("examining scalar staticness for fn %s", fn_name)
-		fn_def.operation.generate(context)
+		scalar_staticness_visitor.generate(fn_def.operation, context)
 
-		patch_model(function_staticness)
 		logger.debug("examining function staticness for fn %s", fn_name)
 
 		if arch.FunctionAttribute.ETISS_NEEDS_ARCH in fn_def.attributes and arch.FunctionAttribute.ETISS_STATICFN in fn_def.attributes:
@@ -63,23 +67,24 @@ def process_functions(core: arch.CoreDef):
 				fn_def.static = True
 
 		else:
-			ret = fn_def.operation.generate(None)
+			ret = function_staticness_visitor.generate(fn_def.operation, None)
 			fn_def.static = ret
 
 def process_instructions(core: arch.CoreDef):
 	"""Apply all preprocessing to all instructions in `core`."""
 
-	for _, instr_def in core.instructions.items():
-		patch_model(expr_simplifier)
-		logger.debug("simplifying expressions for instr %s", instr_def.name)
-		instr_def.operation.generate(None)
+	simplifier = ExprSimplifierVisitor()
+	function_throws_visitor = FunctionThrowsVisitor()
+	scalar_staticness_visitor = ScalarStaticnessVisitor()
 
-		patch_model(function_throws)
+	for _, instr_def in core.instructions.items():
+		logger.debug("simplifying expressions for instr %s", instr_def.name)
+		simplifier.generate(instr_def.operation, None)
+
 		logger.debug("checking throws for instr %s", instr_def.name)
-		throws = instr_def.operation.generate(None)
+		throws = function_throws_visitor.generate(instr_def.operation, None)
 		instr_def.throws = throws
 
 		context = ScalarStaticnessContext()
-		patch_model(scalar_staticness)
 		logger.debug("examining staticness for instr %s", instr_def.name)
-		instr_def.operation.generate(context)
+		scalar_staticness_visitor.generate(instr_def.operation, context)

--- a/m2isar/metamodel/utils/expr_simplifier.py
+++ b/m2isar/metamodel/utils/expr_simplifier.py
@@ -21,214 +21,236 @@ simplifications are done:
 """
 
 from ...metamodel import arch, behav
+from .ExprVisitor import ExprVisitor
+from functools import singledispatchmethod
 
 # pylint: disable=unused-argument
 
-def operation(self: behav.Operation, context):
-	statements = []
-	for stmt in self.statements:
-		try:
-			temp = stmt.generate(context)
-			if isinstance(temp, list):
-				statements.extend(temp)
+class ExprSimplifierVisitor(ExprVisitor):
+	"""Visitor that simplifies behavior expression trees."""
+
+	@singledispatchmethod
+	def generate(self, expr : behav.BaseNode, context=None):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
+
+
+	@generate.register
+	def _(self, expr: behav.Operation, context):
+		statements = []
+		for stmt in expr.statements:
+			try:
+				temp = self.generate(stmt, context)
+				if isinstance(temp, list):
+					statements.extend(temp)
+				else:
+					statements.append(temp)
+			except (NotImplementedError, ValueError):
+				print(f"cant simplify {stmt}")
+
+		expr.statements = statements
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.Block, context):
+		expr.statements = [self.generate(x, context) for x in expr.statements]
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.BinaryOperation, context):
+		expr.left = self.generate(expr.left, context)
+		expr.right = self.generate(expr.right, context)
+
+		if isinstance(expr.left, behav.IntLiteral) and isinstance(expr.right, (behav.NamedReference, behav.IndexedReference)):
+			if expr.left.bit_size < expr.right.reference.size:
+				expr.left.bit_size = expr.right.reference.size
+
+		if isinstance(expr.right, behav.IntLiteral) and isinstance(expr.left, (behav.NamedReference, behav.IndexedReference)):
+			if expr.right.bit_size < expr.left.reference.size:
+				expr.right.bit_size = expr.left.reference.size
+
+		if isinstance(expr.left, behav.IntLiteral) and isinstance(expr.right, behav.IntLiteral):
+			# pylint: disable=eval-used
+			res: int = int(eval(f"{expr.left.value}{expr.op.value}{expr.right.value}"))
+			return behav.IntLiteral(res, max(expr.left.bit_size, expr.right.bit_size, res.bit_length()))
+
+		if expr.op.value == "&&":
+			if isinstance(expr.left, behav.IntLiteral):
+				if expr.left.value:
+					return expr.right
+				return expr.left
+
+			if isinstance(expr.right, behav.IntLiteral):
+				if expr.right.value:
+					return expr.left
+				return expr.right
+
+		if expr.op.value == "||":
+			if isinstance(expr.left, behav.IntLiteral):
+				if expr.left.value:
+					return expr.left
+				return expr.right
+
+			if isinstance(expr.right, behav.IntLiteral):
+				if expr.right.value:
+					return expr.right
+				return expr.left
+
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.SliceOperation, context):
+		expr.expr = self.generate(expr.expr, context)
+		expr.left = self.generate(expr.left, context)
+		expr.right = self.generate(expr.right, context)
+
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.ConcatOperation, context):
+		expr.left = self.generate(expr.left, context)
+		expr.right = self.generate(expr.right, context)
+
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.NumberLiteral, context):
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.IntLiteral, context):
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.StringLiteral, context):
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.ScalarDefinition, context):
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.Break, context):
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.Assignment, context):
+		expr.target = self.generate(expr.target, context)
+		expr.expr = self.generate(expr.expr, context)
+
+		if isinstance(expr.expr, behav.IntLiteral) and isinstance(expr.target, (behav.NamedReference, behav.IndexedReference)):
+			if expr.expr.bit_size < expr.target.reference.size:
+				expr.expr.bit_size = expr.target.reference.size
+
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.Conditional, context):
+		expr.conds = [self.generate(x, context) for x in expr.conds]
+		expr.stmts = [self.generate(x, context) for x in expr.stmts]
+
+		eval_false = True
+
+		conds = []
+		stmts = []
+
+		for cond, stmt in zip(expr.conds, expr.stmts):
+			if isinstance(cond, behav.IntLiteral):
+				if cond.value:
+					return stmt
 			else:
-				statements.append(temp)
-		except (NotImplementedError, ValueError):
-			print(f"cant simplify {stmt}")
+				conds.append(cond)
+				stmts.append(stmt)
+				eval_false = False
 
-	self.statements = statements
-	return self
+		if len(expr.conds) < len(expr.stmts):
+			if eval_false and isinstance(expr.conds[-1], behav.IntLiteral):
+				if not cond.value:  # pylint: disable=undefined-loop-variable
+					return expr.stmts[-1]
+			stmts.append(expr.stmts[-1])
 
-def block(self: behav.Block, context):
-	self.statements = [x.generate(context) for x in self.statements]
-	return self
+		expr.conds = conds
+		expr.stmts = stmts
 
-def binary_operation(self: behav.BinaryOperation, context):
-	self.left = self.left.generate(context)
-	self.right = self.right.generate(context)
+		return expr
 
-	if isinstance(self.left, behav.IntLiteral) and isinstance(self.right, (behav.NamedReference, behav.IndexedReference)):
-		if self.left.bit_size < self.right.reference.size:
-			self.left.bit_size = self.right.reference.size
+	@generate.register
+	def _(self, expr: behav.Loop, context):
+		expr.cond = self.generate(expr.cond, context)
+		expr.stmts = [self.generate(x, context) for x in expr.stmts]
 
-	if isinstance(self.right, behav.IntLiteral) and isinstance(self.left, (behav.NamedReference, behav.IndexedReference)):
-		if self.right.bit_size < self.left.reference.size:
-			self.right.bit_size = self.left.reference.size
+		return expr
 
-	if isinstance(self.left, behav.IntLiteral) and isinstance(self.right, behav.IntLiteral):
-		# pylint: disable=eval-used
-		res: int = int(eval(f"{self.left.value}{self.op.value}{self.right.value}"))
-		return behav.IntLiteral(res, max(self.left.bit_size, self.right.bit_size, res.bit_length()))
+	@generate.register
+	def _(self, expr: behav.Ternary, context):
+		expr.cond = self.generate(expr.cond, context)
+		expr.then_expr = self.generate(expr.then_expr, context)
+		expr.else_expr = self.generate(expr.else_expr, context)
 
-	if self.op.value == "&&":
-		if isinstance(self.left, behav.IntLiteral):
-			if self.left.value:
-				return self.right
-			else:
-				return self.left
+		if isinstance(expr.cond, behav.IntLiteral):
+			if expr.cond.value:
+				return expr.then_expr
 
-		if isinstance(self.right, behav.IntLiteral):
-			if self.right.value:
-				return self.left
-			else:
-				return self.right
+			return expr.else_expr
 
-	if self.op.value == "||":
-		if isinstance(self.left, behav.IntLiteral):
-			if self.left.value:
-				return self.left
-			else:
-				return self.right
+		return expr
 
-		if isinstance(self.right, behav.IntLiteral):
-			if self.right.value:
-				return self.right
-			else:
-				return self.left
+	@generate.register
+	def _(self, expr: behav.Return, context):
+		if expr.expr is not None:
+			expr.expr = self.generate(expr.expr, context)
 
-	return self
+		return expr
 
-def slice_operation(self: behav.SliceOperation, context):
-	self.expr = self.expr.generate(context)
-	self.left = self.left.generate(context)
-	self.right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.UnaryOperation, context):
+		expr.right = self.generate(expr.right, context)
+		if isinstance(expr.right, behav.IntLiteral):
+			# pylint: disable=eval-used
+			res: int = eval(f"{expr.op.value}{expr.right.value}")
+			return behav.IntLiteral(res, max(expr.right.bit_size, res.bit_length()))
 
-	return self
+		return expr
 
-def concat_operation(self: behav.ConcatOperation, context):
-	self.left = self.left.generate(context)
-	self.right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.NamedReference, context):
+		if isinstance(expr.reference, arch.Constant):
+			return behav.IntLiteral(expr.reference.value, expr.reference.size, expr.reference.signed)
 
-	return self
+		return expr
 
-def number_literal(self: behav.NumberLiteral, context):
-	return self
+	@generate.register
+	def _(self, expr: behav.IndexedReference, context):
+		expr.index = self.generate(expr.index, context)
 
-def int_literal(self: behav.IntLiteral, context):
-	return self
+		return expr
 
-def string_literal(self: behav.StringLiteral, context):
-	return self
+	@generate.register
+	def _(self, expr: behav.TypeConv, context):
+		expr.expr = self.generate(expr.expr, context)
+		if isinstance(expr.expr, behav.IntLiteral):
+			expr.expr.bit_size = expr.size
+			expr.expr.signed = expr.data_type == arch.DataType.S
+			return expr.expr
 
-def scalar_definition(self: behav.ScalarDefinition, context):
-	return self
+		return expr
 
-def break_(self: behav.Break, context):
-	return self
+	@generate.register
+	def _(self, expr: behav.Callable, context):
+		expr.args = [self.generate(stmt, context) for stmt in expr.args]
 
-def assignment(self: behav.Assignment, context):
-	self.target = self.target.generate(context)
-	self.expr = self.expr.generate(context)
+		return expr
 
-	if isinstance(self.expr, behav.IntLiteral) and isinstance(self.target, (behav.NamedReference, behav.IndexedReference)):
-		if self.expr.bit_size < self.target.reference.size:
-			self.expr.bit_size = self.target.reference.size
+	@generate.register
+	def _(self, expr: behav.ProcedureCall, context):
+		expr.args = [self.generate(stmt, context) for stmt in expr.args]
 
-	#if isinstance(self.expr, behav.IntLiteral) and isinstance(self.target, behav.ScalarDefinition):
-#		self.target.scalar.value = self.expr.value
+		return expr
 
-	return self
+	@generate.register
+	def _(self, expr: behav.Group, context):
+		expr.expr = self.generate(expr.expr, context)
 
-def conditional(self: behav.Conditional, context):
-	self.conds = [x.generate(context) for x in self.conds]
-	self.stmts = [x.generate(context) for x in self.stmts]
+		if isinstance(expr.expr, behav.IntLiteral):
+			return expr.expr
 
-	eval_false = True
-
-	conds = []
-	stmts = []
-
-	for cond, stmt in zip(self.conds, self.stmts):
-		if isinstance(cond, behav.IntLiteral):
-			if cond.value:
-				return stmt
-		else:
-			conds.append(cond)
-			stmts.append(stmt)
-			eval_false = False
-
-	if len(self.conds) < len(self.stmts):
-		if eval_false and isinstance(self.conds[-1], behav.IntLiteral):
-			if not cond.value: # pylint: disable=undefined-loop-variable
-				return self.stmts[-1]
-		stmts.append(self.stmts[-1])
-
-	self.conds = conds
-	self.stmts = stmts
-
-	return self
-
-def loop(self: behav.Loop, context):
-	self.cond = self.cond.generate(context)
-	self.stmts = [x.generate(context) for x in self.stmts]
-
-	return self
-
-def ternary(self: behav.Ternary, context):
-	self.cond = self.cond.generate(context)
-	self.then_expr = self.then_expr.generate(context)
-	self.else_expr = self.else_expr.generate(context)
-
-	if isinstance(self.cond, behav.IntLiteral):
-		if self.cond.value:
-			return self.then_expr
-
-		return self.else_expr
-
-	return self
-
-def return_(self: behav.Return, context):
-	if self.expr is not None:
-		self.expr = self.expr.generate(context)
-
-	return self
-
-def unary_operation(self: behav.UnaryOperation, context):
-	self.right = self.right.generate(context)
-	if isinstance(self.right, behav.IntLiteral):
-		# pylint: disable=eval-used
-		res: int = eval(f"{self.op.value}{self.right.value}")
-		return behav.IntLiteral(res, max(self.right.bit_size, res.bit_length()))
-
-	return self
-
-def named_reference(self: behav.NamedReference, context):
-	if isinstance(self.reference, arch.Constant):
-		return behav.IntLiteral(self.reference.value, self.reference.size, self.reference.signed)
-
-	#if isinstance(self.reference, arch.Scalar) and self.reference.value is not None:
-#		return behav.IntLiteral(self.reference.value, self.reference.size, self.reference.data_type == arch.DataType.S)
-
-	return self
-
-def indexed_reference(self: behav.IndexedReference, context):
-	self.index = self.index.generate(context)
-
-	return self
-
-def type_conv(self: behav.TypeConv, context):
-	self.expr = self.expr.generate(context)
-	if isinstance(self.expr, behav.IntLiteral):
-		self.expr.bit_size = self.size
-		self.expr.signed = self.data_type == arch.DataType.S
-		return self.expr
-
-	return self
-
-def callable_(self: behav.Callable, context):
-	self.args = [stmt.generate(context) for stmt in self.args]
-
-	return self
-
-def procedure_call(self: behav.ProcedureCall, context):
-	self.args = [stmt.generate(context) for stmt in self.args]
-
-	return self
-
-def group(self: behav.Group, context):
-	self.expr = self.expr.generate(context)
-
-	if isinstance(self.expr, behav.IntLiteral):
-		return self.expr
-
-	return self
+		return expr

--- a/m2isar/metamodel/utils/function_staticness.py
+++ b/m2isar/metamodel/utils/function_staticness.py
@@ -8,132 +8,168 @@
 
 """Transformation functions to determine whether a function is considered to be static."""
 
+from functools import singledispatchmethod
+
 from ...metamodel import arch, behav
+from .ExprVisitor import ExprVisitor
 
 # pylint: disable=unused-argument
 
-def operation(self: behav.Operation, context):
-	statements = []
-	for stmt in self.statements:
-		temp = stmt.generate(context)
-		if isinstance(temp, list):
-			statements.extend(temp)
-		else:
-			statements.append(temp)
+class FunctionStaticnessVisitor(ExprVisitor):
+	"""Visitor that determines whether behavior expression trees are static."""
 
-	return all(statements)
+	@singledispatchmethod
+	def generate(self, expr: behav.BaseNode, context=None):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
 
+	@generate.register
+	def _(self, expr: behav.Operation, context):
+		statements = []
+		for stmt in expr.statements:
+			temp = self.generate(stmt, context)
+			if isinstance(temp, list):
+				statements.extend(temp)
+			else:
+				statements.append(temp)
 
-def block(self: behav.Block, context):
-	stmts = [x.generate(context) for x in self.statements]
-	return all(stmts)
+		return all(statements)
 
+	@generate.register
+	def _(self, expr: behav.Block, context):
+		stmts = [self.generate(x, context) for x in expr.statements]
+		return all(stmts)
 
-def binary_operation(self: behav.BinaryOperation, context):
-	left = self.left.generate(context)
-	right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.BinaryOperation, context):
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
 
-	return all([left, right])
+		return all([left, right])
 
-def slice_operation(self: behav.SliceOperation, context):
-	expr = self.expr.generate(context)
-	left = self.left.generate(context)
-	right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.SliceOperation, context):
+		expr_result = self.generate(expr.expr, context)
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
 
-	return all([expr, left, right])
+		return all([expr_result, left, right])
 
-def concat_operation(self: behav.ConcatOperation, context):
-	left = self.left.generate(context)
-	right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.ConcatOperation, context):
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
 
-	return all([left, right])
+		return all([left, right])
 
-def number_literal(self: behav.NumberLiteral, context):
-	return True
+	@generate.register
+	def _(self, expr: behav.NumberLiteral, context):
+		return True
 
-def int_literal(self: behav.IntLiteral, context):
-	return True
+	@generate.register
+	def _(self, expr: behav.IntLiteral, context):
+		return True
 
-def string_literal(self: behav.StringLiteral, context):
-	return True
+	@generate.register
+	def _(self, expr: behav.StringLiteral, context):
+		return True
 
-def scalar_definition(self: behav.ScalarDefinition, context):
-	return True
+	@generate.register
+	def _(self, expr: behav.ScalarDefinition, context):
+		return True
 
-def break_(self: behav.Break, context):
-	return True
+	@generate.register
+	def _(self, expr: behav.Break, context):
+		return True
 
-def assignment(self: behav.Assignment, context):
-	target = self.target.generate(context)
-	expr = self.expr.generate(context)
+	@generate.register
+	def _(self, expr: behav.Assignment, context):
+		target = self.generate(expr.target, context)
+		expr_result = self.generate(expr.expr, context)
 
-	return all([target, expr])
+		return all([target, expr_result])
 
-def conditional(self: behav.Conditional, context):
-	conds = [x.generate(context) for x in self.conds]
-	stmts = [x.generate(context) for x in self.stmts]
+	@generate.register
+	def _(self, expr: behav.Conditional, context):
+		conds = [self.generate(x, context) for x in expr.conds]
+		stmts = [self.generate(x, context) for x in expr.stmts]
 
-	conds.extend(stmts)
+		conds.extend(stmts)
 
-	return all(conds)
+		return all(conds)
 
-def loop(self: behav.Loop, context):
-	cond = self.cond.generate(context)
-	stmts = [x.generate(context) for x in self.stmts]
-	stmts.append(cond)
+	@generate.register
+	def _(self, expr: behav.Loop, context):
+		cond = self.generate(expr.cond, context)
+		stmts = [self.generate(x, context) for x in expr.stmts]
+		stmts.append(cond)
 
-	return all(stmts)
+		return all(stmts)
 
-def ternary(self: behav.Ternary, context):
-	cond = self.cond.generate(context)
-	then_expr = self.then_expr.generate(context)
-	else_expr = self.else_expr.generate(context)
+	@generate.register
+	def _(self, expr: behav.Ternary, context):
+		cond = self.generate(expr.cond, context)
+		then_expr = self.generate(expr.then_expr, context)
+		else_expr = self.generate(expr.else_expr, context)
 
-	return all([cond, then_expr, else_expr])
+		return all([cond, then_expr, else_expr])
 
-def return_(self: behav.Return, context):
-	if self.expr is not None:
-		return self.expr.generate(context)
+	@generate.register
+	def _(self, expr: behav.Return, context):
+		if expr.expr is not None:
+			return self.generate(expr.expr, context)
 
-	return True
+		return True
 
-def unary_operation(self: behav.UnaryOperation, context):
-	right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.UnaryOperation, context):
+		right = self.generate(expr.right, context)
 
-	return right
+		return right
 
-def named_reference(self: behav.NamedReference, context):
-	if isinstance(self.reference, arch.Scalar):
-		return self.reference.static
+	@generate.register
+	def _(self, expr: behav.NamedReference, context):
+		if isinstance(expr.reference, arch.Scalar):
+			return expr.reference.static
 
-	static_map = {
-		arch.Memory: False,
-		arch.BitFieldDescr: True,
-		arch.Constant: True,
-		arch.FnParam: True,
-		arch.Scalar: True,
-		arch.Intrinsic: False
-	}
+		static_map = {
+			arch.Memory: False,
+			arch.BitFieldDescr: True,
+			arch.Constant: True,
+			arch.FnParam: True,
+			arch.Scalar: True,
+			arch.Intrinsic: False
+		}
 
-	return static_map.get(type(self.reference), False)
+		return static_map.get(type(expr.reference), False)
 
-def indexed_reference(self: behav.IndexedReference, context):
-	self.index.generate(context)
+	@generate.register
+	def _(self, expr: behav.IndexedReference, context):
+		self.generate(expr.index, context)
 
-	return False
+		return False
 
-def type_conv(self: behav.TypeConv, context):
-	expr = self.expr.generate(context)
+	@generate.register
+	def _(self, expr: behav.TypeConv, context):
+		expr_result = self.generate(expr.expr, context)
 
-	return expr
+		return expr_result
 
-def callable_(self: behav.Callable, context):
-	args = [arg.generate(context) for arg in self.args]
-	args.append(self.ref_or_name.static)
+	@generate.register
+	def _(self, expr: behav.Callable, context):
+		args = [self.generate(arg, context) for arg in expr.args]
+		args.append(bool(getattr(expr.ref_or_name, "static", False)))
 
-	return all(args)
+		return all(args)
 
-def group(self: behav.Group, context):
-	expr = self.expr.generate(context)
+	@generate.register
+	def _(self, expr: behav.ProcedureCall, context):
+		args = [self.generate(arg, context) for arg in expr.args]
+		args.append(bool(getattr(expr.ref_or_name, "static", False)))
 
-	return expr
+		return all(args)
+
+	@generate.register
+	def _(self, expr: behav.Group, context):
+		expr_result = self.generate(expr.expr, context)
+
+		return expr_result

--- a/m2isar/metamodel/utils/function_throws.py
+++ b/m2isar/metamodel/utils/function_throws.py
@@ -51,7 +51,7 @@ def concat_operation(self: behav.ConcatOperation, context):
 
 	return reduce(or_, [left, right])
 
-def number_literal(self: behav.IntLiteral, context):
+def number_literal(self: behav.NumberLiteral, context):
 	return arch.FunctionThrows.NO
 
 def int_literal(self: behav.IntLiteral, context):

--- a/m2isar/metamodel/utils/function_throws.py
+++ b/m2isar/metamodel/utils/function_throws.py
@@ -9,133 +9,171 @@
 """Tranformation functions to determine whether a function throws an exception."""
 
 from functools import reduce
+from functools import singledispatchmethod
 from operator import or_
+from typing import Any
 
 from ...metamodel import arch, behav
+from .ExprVisitor import ExprVisitor
 
 # pylint: disable=unused-argument
 
-def operation(self: behav.Operation, context):
-	statements = []
-	for stmt in self.statements:
-		temp = stmt.generate(context)
-		if isinstance(temp, list):
-			statements.extend(temp)
-		else:
-			statements.append(temp)
+class FunctionThrowsVisitor(ExprVisitor):
+	"""Visitor that determines whether behavior expression trees can throw exceptions."""
 
-	return reduce(or_, statements, arch.FunctionThrows.NO)
+	@singledispatchmethod
+	def generate(self, expr: behav.BaseNode, context=None):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
+
+	@generate.register
+	def _(self, expr: behav.Operation, context):
+		statements = []
+		for stmt in expr.statements:
+			temp = self.generate(stmt, context)
+			if isinstance(temp, list):
+				statements.extend(temp)
+			else:
+				statements.append(temp)
+
+		return reduce(or_, statements, arch.FunctionThrows.NO)
+
+	@generate.register
+	def _(self, expr: behav.Block, context):
+		stmts = [self.generate(x, context) for x in expr.statements]
+		return reduce(or_, stmts, arch.FunctionThrows.NO)
+
+	@generate.register
+	def _(self, expr: behav.BinaryOperation, context):
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
+
+		return reduce(or_, [left, right])
+
+	@generate.register
+	def _(self, expr: behav.SliceOperation, context):
+		expr_result = self.generate(expr.expr, context)
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
+
+		return reduce(or_, [expr_result, left, right])
+
+	@generate.register
+	def _(self, expr: behav.ConcatOperation, context):
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
+
+		return reduce(or_, [left, right])
+
+	@generate.register
+	def _(self, expr: behav.NumberLiteral, context):
+		return arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.IntLiteral, context):
+		return arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.StringLiteral, context):
+		return arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.ScalarDefinition, context):
+		return arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.Break, context):
+		return arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.Assignment, context):
+		target = self.generate(expr.target, context)
+		expr_result = self.generate(expr.expr, context)
+
+		return reduce(or_, [target, expr_result])
+
+	@generate.register
+	def _(self, expr: behav.Conditional, context):
+		conds = [self.generate(x, context) for x in expr.conds]
+		stmts = [self.generate(x, context) for x in expr.stmts]
+
+		conds.extend(stmts)
+
+		return arch.FunctionThrows.MAYBE if reduce(or_, conds) else arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.Loop, context):
+		cond = self.generate(expr.cond, context)
+		stmts = [self.generate(x, context) for x in expr.stmts]
+		stmts.append(cond)
+
+		return reduce(or_, stmts)
+
+	@generate.register
+	def _(self, expr: behav.Ternary, context):
+		cond = self.generate(expr.cond, context)
+		then_expr = self.generate(expr.then_expr, context)
+		else_expr = self.generate(expr.else_expr, context)
+
+		return reduce(or_, [cond, then_expr, else_expr])
+
+	@generate.register
+	def _(self, expr: behav.Return, context):
+		if expr.expr is not None:
+			return self.generate(expr.expr, context)
+
+		return arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.UnaryOperation, context):
+		right = self.generate(expr.right, context)
+
+		return right
+
+	@generate.register
+	def _(self, expr: behav.NamedReference, context):
+		if isinstance(expr.reference, arch.Memory) and arch.MemoryAttribute.ETISS_CAN_FAIL in expr.reference.attributes:
+			return arch.FunctionThrows.YES
+
+		return arch.FunctionThrows.NO
+
+	@generate.register
+	def _(self, expr: behav.IndexedReference, context):
+		if isinstance(expr.reference, arch.Memory) and arch.MemoryAttribute.ETISS_CAN_FAIL in expr.reference.attributes:
+			return arch.FunctionThrows.YES
+
+		return self.generate(expr.index, context)
+
+	@generate.register
+	def _(self, expr: behav.TypeConv, context):
+		expr_result = self.generate(expr.expr, context)
+
+		return expr_result
+
+	@generate.register
+	def _(self, expr: behav.Callable, context):
+		args = [self.generate(arg, context) for arg in expr.args]
+		throws = getattr(expr.ref_or_name, "throws", arch.FunctionThrows.NO)
+		args.append(throws if isinstance(throws, arch.FunctionThrows) else cast_to_throws(throws))
+
+		return reduce(or_, args)
+
+	@generate.register
+	def _(self, expr: behav.ProcedureCall, context):
+		args = [self.generate(arg, context) for arg in expr.args]
+		throws = getattr(expr.ref_or_name, "throws", arch.FunctionThrows.NO)
+		args.append(throws if isinstance(throws, arch.FunctionThrows) else cast_to_throws(throws))
+
+		return reduce(or_, args)
+
+	@generate.register
+	def _(self, expr: behav.Group, context):
+		expr_result = self.generate(expr.expr, context)
+
+		return expr_result
 
 
-def block(self: behav.Block, context):
-	stmts = [x.generate(context) for x in self.statements]
-	return reduce(or_, stmts, arch.FunctionThrows.NO)
-
-
-def binary_operation(self: behav.BinaryOperation, context):
-	left = self.left.generate(context)
-	right = self.right.generate(context)
-
-	return reduce(or_, [left, right])
-
-def slice_operation(self: behav.SliceOperation, context):
-	expr = self.expr.generate(context)
-	left = self.left.generate(context)
-	right = self.right.generate(context)
-
-	return reduce(or_, [expr, left, right])
-
-def concat_operation(self: behav.ConcatOperation, context):
-	left = self.left.generate(context)
-	right = self.right.generate(context)
-
-	return reduce(or_, [left, right])
-
-def number_literal(self: behav.NumberLiteral, context):
-	return arch.FunctionThrows.NO
-
-def int_literal(self: behav.IntLiteral, context):
-	return arch.FunctionThrows.NO
-
-def string_literal(self: behav.StringLiteral, context):
-	return arch.FunctionThrows.NO
-
-def scalar_definition(self: behav.ScalarDefinition, context):
-	return arch.FunctionThrows.NO
-
-def break_(self: behav.Break, context):
-	return arch.FunctionThrows.NO
-
-def assignment(self: behav.Assignment, context):
-	target = self.target.generate(context)
-	expr = self.expr.generate(context)
-
-	return reduce(or_, [target, expr])
-
-def conditional(self: behav.Conditional, context):
-	conds = [x.generate(context) for x in self.conds]
-	stmts = [x.generate(context) for x in self.stmts]
-
-	conds.extend(stmts)
-
-	return arch.FunctionThrows.MAYBE if reduce(or_, conds) else arch.FunctionThrows.NO
-
-def loop(self: behav.Loop, context):
-	cond = self.cond.generate(context)
-	stmts = [x.generate(context) for x in self.stmts]
-	stmts.append(cond)
-
-	return reduce(or_, stmts)
-
-def ternary(self: behav.Ternary, context):
-	cond = self.cond.generate(context)
-	then_expr = self.then_expr.generate(context)
-	else_expr = self.else_expr.generate(context)
-
-	return reduce(or_, [cond, then_expr, else_expr])
-
-def return_(self: behav.Return, context):
-	if self.expr is not None:
-		return self.expr.generate(context)
-
-	return arch.FunctionThrows.NO
-
-def unary_operation(self: behav.UnaryOperation, context):
-	right = self.right.generate(context)
-
-	return right
-
-def named_reference(self: behav.NamedReference, context):
-	if isinstance(self.reference, arch.Memory) and arch.MemoryAttribute.ETISS_CAN_FAIL in self.reference.attributes:
-		return arch.FunctionThrows.YES
-
-	return arch.FunctionThrows.NO
-
-def indexed_reference(self: behav.IndexedReference, context):
-	if isinstance(self.reference, arch.Memory) and arch.MemoryAttribute.ETISS_CAN_FAIL in self.reference.attributes:
-		return arch.FunctionThrows.YES
-
-	return self.index.generate(context)
-
-def type_conv(self: behav.TypeConv, context):
-	expr = self.expr.generate(context)
-
-	return expr
-
-def callable_(self: behav.Callable, context):
-	args = [arg.generate(context) for arg in self.args]
-	args.append(self.ref_or_name.throws)
-
-	return reduce(or_, args)
-
-
-def procedure_call(self: behav.ProcedureCall, context):
-	args = [arg.generate(context) for arg in self.args]
-	args.append(self.ref_or_name.throws)
-
-	return reduce(or_, args)
-
-def group(self: behav.Group, context):
-	expr = self.expr.generate(context)
-
-	return expr
+def cast_to_throws(throws: Any) -> arch.FunctionThrows:
+	"""Cast unknown throws values into FunctionThrows for robust visitor dispatch."""
+	if isinstance(throws, bool):
+		return arch.FunctionThrows.YES if throws else arch.FunctionThrows.NO
+	return arch.FunctionThrows(throws)

--- a/m2isar/metamodel/utils/scalar_staticness.py
+++ b/m2isar/metamodel/utils/scalar_staticness.py
@@ -11,141 +11,183 @@ behavior are to be considered static.
 """
 
 import dataclasses
+from functools import singledispatchmethod
+from typing import Any, cast
 
 from ...metamodel import arch, behav
 from ...metamodel.utils import ScalarStaticnessContext, StaticType
+from .ExprVisitor import ExprVisitor
 
 # pylint: disable=unused-argument
 
-def operation(self: behav.Operation, context: ScalarStaticnessContext):
-	statements = []
-	for stmt in self.statements:
-		temp = stmt.generate(context)
-		if isinstance(temp, list):
-			statements.extend(temp)
+class ScalarStaticnessVisitor(ExprVisitor):
+	"""Visitor that determines scalar staticness for behavior expression trees."""
+
+	@singledispatchmethod
+	def generate(self, expr: behav.BaseNode, context=None):
+		raise NotImplementedError(f"No visit method implemented for type {type(expr).__name__} in {type(expr).__name__}")
+
+	@generate.register
+	def _(self, expr: behav.Operation, context: ScalarStaticnessContext):
+		statements = []
+		for stmt in expr.statements:
+			temp = self.generate(stmt, context)
+			if isinstance(temp, list):
+				statements.extend(temp)
+			else:
+				statements.append(temp)
+
+		return expr
+
+	@generate.register
+	def _(self, expr: behav.Block, context):
+		stmts = [self.generate(x, context) for x in expr.statements]
+		valid = [s for s in stmts if s is not None]
+		if not valid:
+			return StaticType.NONE
+		return min(valid)
+
+	@generate.register
+	def _(self, expr: behav.BinaryOperation, context: ScalarStaticnessContext):
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
+
+		return min(left, right)
+
+	@generate.register
+	def _(self, expr: behav.SliceOperation, context: ScalarStaticnessContext):
+		expr_result = self.generate(expr.expr, context)
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
+
+		return min(expr_result, left, right)
+
+	@generate.register
+	def _(self, expr: behav.ConcatOperation, context: ScalarStaticnessContext):
+		left = self.generate(expr.left, context)
+		right = self.generate(expr.right, context)
+
+		return min(left, right)
+
+	@generate.register
+	def _(self, expr: behav.NumberLiteral, context: ScalarStaticnessContext):
+		return StaticType.READ
+
+	@generate.register
+	def _(self, expr: behav.IntLiteral, context: ScalarStaticnessContext):
+		return StaticType.READ
+
+	@generate.register
+	def _(self, expr: behav.StringLiteral, context: ScalarStaticnessContext):
+		return StaticType.READ
+
+	@generate.register
+	def _(self, expr: behav.ScalarDefinition, context: ScalarStaticnessContext):
+		scalar = cast(Any, expr.scalar)
+		scalar.static = StaticType.RW
+		return StaticType.RW
+
+	@generate.register
+	def _(self, expr: behav.Break, context):
+		return StaticType.READ
+
+	@generate.register
+	def _(self, expr: behav.Assignment, context: ScalarStaticnessContext):
+		self.generate(expr.target, context)
+
+		if context.context_is_static != StaticType.NONE or isinstance(expr.target, behav.ScalarDefinition):
+			expr_static = self.generate(expr.expr, context)
+
+			if expr_static != StaticType.NONE:
+				expr_static = StaticType.RW
 		else:
-			statements.append(temp)
+			expr_static = StaticType.NONE
 
-	return self
+		if isinstance(expr.target, behav.NamedReference) and isinstance(expr.target.reference, arch.Scalar):
+			target_ref = cast(Any, expr.target.reference)
+			target_ref.static &= expr_static
 
-def block(self: behav.Block, context):
-	stmts = [x.generate(context) for x in self.statements]
-	valid = [s for s in stmts if s is not None]
-	if not valid:
+		if isinstance(expr.target, behav.ScalarDefinition):
+			target_scalar = cast(Any, expr.target.scalar)
+			target_scalar.static &= expr_static
+
+	@generate.register
+	def _(self, expr: behav.Conditional, context: ScalarStaticnessContext):
+		conds = [self.generate(x, context) for x in expr.conds]
+		stmt_context = dataclasses.replace(context, context_is_static=min(conds))
+		_ = [self.generate(x, stmt_context) for x in expr.stmts]
+
+	@generate.register
+	def _(self, expr: behav.Loop, context: ScalarStaticnessContext):
+		cond = self.generate(expr.cond, context)
+		stmt_context = dataclasses.replace(context, context_is_static=cond)
+		_ = [self.generate(x, stmt_context) for x in expr.stmts]
+
+	@generate.register
+	def _(self, expr: behav.Ternary, context: ScalarStaticnessContext):
+		cond = self.generate(expr.cond, context)
+		then_expr = self.generate(expr.then_expr, context)
+		else_expr = self.generate(expr.else_expr, context)
+
+		return min(cond, then_expr, else_expr)
+
+	@generate.register
+	def _(self, expr: behav.Return, context: ScalarStaticnessContext):
+		if expr.expr is not None:
+			return self.generate(expr.expr, context)
+
+		return StaticType.RW
+
+	@generate.register
+	def _(self, expr: behav.UnaryOperation, context: ScalarStaticnessContext):
+		right = self.generate(expr.right, context)
+
+		return right
+
+	@generate.register
+	def _(self, expr: behav.NamedReference, context: ScalarStaticnessContext):
+		if isinstance(expr.reference, arch.Scalar):
+			return expr.reference.static
+
+		static_map = {
+			arch.Memory: StaticType.NONE,
+			arch.BitFieldDescr: StaticType.READ,
+			arch.Constant: StaticType.READ,
+			arch.FnParam: StaticType.READ
+		}
+
+		return static_map.get(type(expr.reference), StaticType.NONE)
+
+	@generate.register
+	def _(self, expr: behav.IndexedReference, context: ScalarStaticnessContext):
+		self.generate(expr.index, context)
+
 		return StaticType.NONE
-	return min(valid)
 
-def binary_operation(self: behav.BinaryOperation, context: ScalarStaticnessContext):
-	left = self.left.generate(context)
-	right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.TypeConv, context: ScalarStaticnessContext):
+		expr_result = self.generate(expr.expr, context)
 
-	return min(left, right)
+		return expr_result
 
-def slice_operation(self: behav.SliceOperation, context: ScalarStaticnessContext):
-	expr = self.expr.generate(context)
-	left = self.left.generate(context)
-	right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.Callable, context: ScalarStaticnessContext):
+		args = [self.generate(arg, context) for arg in expr.args]
+		is_static = bool(getattr(expr.ref_or_name, "static", False))
+		args.append(StaticType.READ if is_static else StaticType.NONE)
 
-	return min(expr, left, right)
+		return min(args)
 
-def concat_operation(self: behav.ConcatOperation, context: ScalarStaticnessContext):
-	left = self.left.generate(context)
-	right = self.right.generate(context)
+	@generate.register
+	def _(self, expr: behav.ProcedureCall, context: ScalarStaticnessContext):
+		args = [self.generate(arg, context) for arg in expr.args]
+		is_static = bool(getattr(expr.ref_or_name, "static", False))
+		args.append(StaticType.READ if is_static else StaticType.NONE)
 
-	return min(left, right)
+		return min(args)
 
-def number_literal(self: behav.NumberLiteral, context: ScalarStaticnessContext):
-	return StaticType.READ
+	@generate.register
+	def _(self, expr: behav.Group, context: ScalarStaticnessContext):
+		expr_result = self.generate(expr.expr, context)
 
-def int_literal(self: behav.IntLiteral, context: ScalarStaticnessContext):
-	return StaticType.READ
-
-def string_literal(self: behav.StringLiteral, context: ScalarStaticnessContext):
-	return StaticType.READ
-
-def scalar_definition(self: behav.ScalarDefinition, context: ScalarStaticnessContext):
-	self.scalar.static = StaticType.RW
-	return StaticType.RW
-
-def break_(self: behav.Break, context):
-	return StaticType.READ
-
-def assignment(self: behav.Assignment, context: ScalarStaticnessContext):
-	self.target.generate(context)
-
-	if context.context_is_static != StaticType.NONE or isinstance(self.target, behav.ScalarDefinition):
-		expr = self.expr.generate(context)
-
-		if expr != StaticType.NONE:
-			expr = StaticType.RW
-	else:
-		expr = StaticType.NONE
-
-	if isinstance(self.target, behav.NamedReference) and isinstance(self.target.reference, arch.Scalar):
-		self.target.reference.static &= expr
-
-	if isinstance(self.target, behav.ScalarDefinition):
-		self.target.scalar.static &= expr
-
-
-def conditional(self: behav.Conditional, context: ScalarStaticnessContext):
-	conds = [x.generate(context) for x in self.conds]
-	stmt_context = dataclasses.replace(context, context_is_static=min(conds))
-	_ = [x.generate(stmt_context) for x in self.stmts]
-
-def loop(self: behav.Loop, context: ScalarStaticnessContext):
-	cond = self.cond.generate(context)
-	stmt_context = dataclasses.replace(context, context_is_static=cond)
-	_ = [x.generate(stmt_context) for x in self.stmts]
-
-def ternary(self: behav.Ternary, context: ScalarStaticnessContext):
-	cond = self.cond.generate(context)
-	then_expr = self.then_expr.generate(context)
-	else_expr = self.else_expr.generate(context)
-
-	return min(cond, then_expr, else_expr)
-
-def return_(self: behav.Return, context: ScalarStaticnessContext):
-	if self.expr is not None:
-		return self.expr.generate(context)
-
-	return StaticType.RW
-
-def unary_operation(self: behav.UnaryOperation, context: ScalarStaticnessContext):
-	right = self.right.generate(context)
-
-	return right
-
-def named_reference(self: behav.NamedReference, context: ScalarStaticnessContext):
-	if isinstance(self.reference, arch.Scalar):
-		return self.reference.static
-
-	static_map = {
-		arch.Memory: StaticType.NONE,
-		arch.BitFieldDescr: StaticType.READ,
-		arch.Constant: StaticType.READ,
-		arch.FnParam: StaticType.READ
-	}
-
-	return static_map.get(type(self.reference), StaticType.NONE)
-
-def indexed_reference(self: behav.IndexedReference, context: ScalarStaticnessContext):
-	self.index.generate(context)
-
-	return StaticType.NONE
-
-def type_conv(self: behav.TypeConv, context: ScalarStaticnessContext):
-	expr = self.expr.generate(context)
-
-	return expr
-
-def callable_(self: behav.Callable, context: ScalarStaticnessContext):
-	args = [arg.generate(context) for arg in self.args]
-	args.append(StaticType.READ if self.ref_or_name.static else StaticType.NONE)
-
-	return min(args)
-
-def group(self: behav.Group, context: ScalarStaticnessContext):
-	expr = self.expr.generate(context)
-
-	return expr
+		return expr_result


### PR DESCRIPTION
This is an initial commit and proof of concept aimed at replacing the current patch_model function with an ExprVisitor metaclass that supports overrideable (or optionally enforced) visitor aka generator functions.


The basic patch_model replacement consists of an own Subclass of the ExprVisitor with an own dispatched recursive generate function that differs its behavior regarding its input type (behav.{__type__}).
Therefore no global shared function set exists anymore. Also non existent generation overloads lead to
an NotImplemented exception -> Improvement of determinism 
