### PR TITLE
Ranged mem index

### DIFF
--- a/m2isar/backends/etiss/instruction_transform.py
+++ b/m2isar/backends/etiss/instruction_transform.py
@@ -341,9 +341,6 @@ class InstructionTransformVisitor(ExprVisitor):
 			for m_id in expr_str.mem_ids:
 				m_id.write = False
 
-				if not expr_str.mem_corrected:
-					logger.debug("assuming mem read size at %d", target.size)
-					m_id.access_size = target.size
 
 			if target.is_mem_access:
 				if len(target.mem_ids) != 1:
@@ -351,9 +348,6 @@ class InstructionTransformVisitor(ExprVisitor):
 
 				target.mem_ids[0].write = True
 
-				if not target.mem_corrected:
-					logger.debug("assuming mem write size at %d", expr_str.size)
-					target.mem_ids[0].access_size = expr_str.size
 
 		c = CodeString(f"{target.code} = {expr_str.code};", static, None, None, line_infos=[expr.line_info] + target.line_infos + expr_str.line_infos)
 
@@ -526,13 +520,6 @@ class InstructionTransformVisitor(ExprVisitor):
 			expr._size = expr_str.size
 			expr._actual_size = expr_str.actual_size
 
-		if expr_str.is_mem_access:
-			if not expr_str.mem_corrected and expr_str.mem_ids[-1].access_size != expr.size:
-				expr_str.mem_ids[-1].access_size = expr.size
-				expr_str.size = expr.size
-				expr_str.mem_corrected = True
-			elif expr_str.mem_ids[-1].access_size == expr.size:
-				expr_str.mem_corrected = True
 
 		code_str = expr_str.code
 
@@ -548,7 +535,6 @@ class InstructionTransformVisitor(ExprVisitor):
 
 		c = CodeString(code_str, expr_str.static, expr.size, expr.data_type == arch.DataType.S, expr_str.regs_affected, line_infos=[expr.line_info] + expr_str.line_infos)
 		c.mem_ids = expr_str.mem_ids
-		c.mem_corrected = expr_str.mem_corrected
 
 		return c
 
@@ -632,6 +618,7 @@ class InstructionTransformVisitor(ExprVisitor):
 			static = StaticType.NONE
 
 		if arch.MemoryAttribute.IS_MAIN_MEM in referred_mem.attributes:
+			size = expr.inferred_type._width
 			c = CodeString(f'{MEM_VAL_REPL}{context.mem_var_count}', static, size, False, line_infos=[expr.line_info] + index.line_infos)
 			c.mem_ids.append(MemID(referred_mem, context.mem_var_count, index, size))
 			context.mem_var_count += 1
@@ -640,8 +627,6 @@ class InstructionTransformVisitor(ExprVisitor):
 		code_str = f'{replacements.prefixes.get(name, replacements.default_prefix)}{name}[{index.code}]'
 		if len(referred_mem.children) > 0:
 			code_str = '*' + code_str
-		if size != referred_mem.size:
-			code_str = f'(etiss_uint{size})' + code_str
 		c = CodeString(code_str, static, size, False, line_infos=[expr.line_info] + index.line_infos)
 		if arch.MemoryAttribute.IS_MAIN_REG in referred_mem.attributes:
 			c.regs_affected.add(index_code)

--- a/m2isar/backends/etiss/instruction_transform.py
+++ b/m2isar/backends/etiss/instruction_transform.py
@@ -620,7 +620,18 @@ class InstructionTransformVisitor(ExprVisitor):
 		if arch.MemoryAttribute.IS_MAIN_MEM in referred_mem.attributes:
 			size = expr.inferred_type._width
 			c = CodeString(f'{MEM_VAL_REPL}{context.mem_var_count}', static, size, False, line_infos=[expr.line_info] + index.line_infos)
-			c.mem_ids.append(MemID(referred_mem, context.mem_var_count, index, size))
+			if (expr.right != None):
+				# Use a simple base address on one site atleast for ranged_mem access.
+				# Index Codestring is forwarded into MemID class.
+				right = self.generate(expr.right, context)
+				if(type(expr.index) == behav.NamedReference):
+					c.mem_ids.append(MemID(referred_mem, context.mem_var_count, index, size))
+				elif(type(expr.right) == behav.NamedReference):
+					c.mem_ids.append(MemID(referred_mem, context.mem_var_count, right, size))
+				else:
+					raise(f"IndexedExpr ist needs to be static on one side: But Type is Left: {type(expr.index)} and Right: {type(expr.index)}")
+			else:
+				c.mem_ids.append(MemID(referred_mem, context.mem_var_count, index, size))
 			context.mem_var_count += 1
 			return c
 

--- a/m2isar/backends/etiss/instruction_utils.py
+++ b/m2isar/backends/etiss/instruction_utils.py
@@ -53,7 +53,6 @@ class CodeString:
 		self.signed = signed
 		self.mem_ids = []
 		self.regs_affected = regs_affected if isinstance(regs_affected, set) else set()
-		self.mem_corrected = False
 		self.is_literal = False
 		self.function_calls = []
 		self.check_trap = False

--- a/m2isar/backends/viewer/treegen.py
+++ b/m2isar/backends/viewer/treegen.py
@@ -208,9 +208,31 @@ class TreeGenVisitor(ExprVisitor):
 
 		context.tree.insert(context.parent, tk.END, text="Reference", values=(f"{expr.reference}",))
 
-		context.push(context.tree.insert(context.parent, tk.END, text="Index"))
-		self.generate(expr.index, context)
-		context.pop()
+		# If LHS is a complex expression => RHS also an expression
+		# TODO: Little Endian only so far supported
+		if (expr.reference.name == "MEM"):
+				if expr.right != None:
+						context.push(context.tree.insert(context.parent, tk.END, text="IndexRange"))
+
+						context.push(context.tree.insert(context.parent, tk.END, text="Left"))
+						self.generate(expr.index, context)
+						context.pop()
+						assert(type(expr.right), behav.NamedReference)
+						context.push(context.tree.insert(context.parent, tk.END, text="Right"))
+						self.generate(expr.right, context)
+						context.pop()
+
+						context.pop()
+
+				else:
+						context.push(context.tree.insert(context.parent, tk.END, text="Index"))
+						self.generate(expr.index, context)
+						context.pop()
+
+		else:
+				context.push(context.tree.insert(context.parent, tk.END, text="Index"))
+				self.generate(expr.index, context)
+				context.pop()
 
 		context.pop()
 

--- a/m2isar/frontends/coredsl2/behavior_model_builder.py
+++ b/m2isar/frontends/coredsl2/behavior_model_builder.py
@@ -286,7 +286,11 @@ class BehaviorModelBuilder(CoreDSL2Visitor):
 		right = self.visit(ctx.right) if ctx.right else left
 
 		if isinstance(expr, behav.NamedReference) and isinstance(expr.reference, arch.Memory) and expr.reference.data_range.length > 1:
-			return behav.IndexedReference(expr.reference, left, right, LineInfoFactory.make(ctx.start.source[1].fileName, ctx.start.start, ctx.stop.stop, ctx.start.line, ctx.stop.line))
+			#Dont duplicate index to differentiate between index and ranged access
+			if right == left:
+					return behav.IndexedReference(expr.reference, left, None, LineInfoFactory.make(ctx.start.source[1].fileName, ctx.start.start, ctx.stop.stop, ctx.start.line, ctx.stop.line))
+			else:
+					return behav.IndexedReference(expr.reference, left, right, LineInfoFactory.make(ctx.start.source[1].fileName, ctx.start.start, ctx.stop.stop, ctx.start.line, ctx.stop.line))
 		else:
 			return behav.SliceOperation(expr, left, right, LineInfoFactory.make(ctx.start.source[1].fileName, ctx.start.start, ctx.stop.stop, ctx.start.line, ctx.stop.line))
 

--- a/m2isar/transforms/infer_types/visitor.py
+++ b/m2isar/transforms/infer_types/visitor.py
@@ -405,6 +405,7 @@ def helper_expr_size(sub_expr: behav.BaseNode):
             return helper_expr_size(expr)
     elif type(sub_expr) == behav.BinaryOperation:
             expr = sub_expr
+            assert isinstance(expr.left, behav.NamedReference)
 
             if expr.op.value == "+":
                     if type(expr.right) == behav.IntLiteral:

--- a/m2isar/transforms/infer_types/visitor.py
+++ b/m2isar/transforms/infer_types/visitor.py
@@ -319,7 +319,21 @@ class InferTypesMutator(ExprMutator):
         assert isinstance(expr.reference, arch.Memory)
         ty = arch.DataType.U  # TODO: Memory class should keep track of dtype, not only size?
         assert ty in [arch.DataType.U, arch.DataType.S]
-        size = expr.reference.size
+        single_mem_acc_size = expr.reference.size
+
+        ## Simple eval check for ranged access.
+        # Little-endian interpretation:
+        # - lhs > rhs  → width = lhs - rhs + 1
+        # - lhs == rhs → width = 8 bits
+
+        if expr.right == None:
+            size = single_mem_acc_size
+        if expr.right != None:
+                lhs_offset = helper_expr_size(expr.index)
+                rhs_offset = helper_expr_size(expr.right)
+                assert(lhs_offset >= rhs_offset)
+                size = (lhs_offset - rhs_offset + 1)*single_mem_acc_size
+
         ty_ = arch.IntegerType(size, ty == arch.DataType.S, None)
 
         expr.inferred_type = ty_
@@ -381,3 +395,28 @@ class InferTypesMutator(ExprMutator):
     @generate.register
     def _(self, expr: behav.Break, context):
         return expr
+
+
+# Simple expression evaluation for ranged mem indexes
+def helper_expr_size(sub_expr: behav.BaseNode):
+    expr = None
+    if type(sub_expr) == behav.Group:
+            expr = sub_expr.expr
+            return helper_expr_size(expr)
+    elif type(sub_expr) == behav.BinaryOperation:
+            expr = sub_expr
+
+            if expr.op.value == "+":
+                    if type(expr.right) == behav.IntLiteral:
+                            return int(expr.right.value)
+
+            elif expr.op.value == "-":
+                    if type(expr.right) == behav.IntLiteral:
+                            return (-1 * int(expr.right.value))
+            else:
+                    raise(f"Not supported Operation value Type {expr.op.value} within mem access range")
+
+    elif type(sub_expr) == behav.NamedReference:
+            return 0
+    else:
+            raise(f"Not supported expr Type {type(sub_expr)} within mem access range")

--- a/m2isar/transforms/infer_types/visitor.py
+++ b/m2isar/transforms/infer_types/visitor.py
@@ -23,6 +23,7 @@ simplifications are done:
 import logging
 from copy import copy
 from functools import singledispatchmethod
+from copy import deepcopy
 
 from m2isar.metamodel import arch, behav
 from ...metamodel.utils.ExprMutator import ExprMutator
@@ -330,6 +331,7 @@ class InferTypesMutator(ExprMutator):
         expr.expr = self.generate(expr.expr, context)
 
         ty = expr.expr.inferred_type
+        ty = deepcopy(expr.expr.inferred_type)
         if ty is None:
             logger.warning("Type conv needs inferred type. Skipping...")
             return expr

--- a/m2isar/transforms/infer_types/visitor.py
+++ b/m2isar/transforms/infer_types/visitor.py
@@ -330,7 +330,6 @@ class InferTypesMutator(ExprMutator):
     def _(self, expr: behav.TypeConv, context):
         expr.expr = self.generate(expr.expr, context)
 
-        ty = expr.expr.inferred_type
         ty = deepcopy(expr.expr.inferred_type)
         if ty is None:
             logger.warning("Type conv needs inferred type. Skipping...")


### PR DESCRIPTION
Reintroduces ranged memory access with correct type inference.
This removes the prior hacky implementation with memory correction for compliance with CoreDSL2.

Resolves:
https://github.com/tum-ei-eda/M2-ISA-R/issues/72

Also includes a minor type inference bugfix.