### PR TITLE
[MetaModel] Switch FnParam to new Typing System

### DIFF
--- a/m2isar/backends/etiss/instruction_generator.py
+++ b/m2isar/backends/etiss/instruction_generator.py
@@ -22,7 +22,17 @@ logger = logging.getLogger("instruction_generator")
 
 def generate_arg_str(arg: arch.FnParam):
 	arg_name = f" {arg.name}" if arg.name is not None else ""
-	return f'{instruction_utils.data_type_map[arg.ty.kind]}{actual_size(arg.ty.size)}{arg_name}'
+	if isinstance(arg.ty, type_info.PrimitiveType):
+		arg_type = instruction_utils.data_type_map[arg.ty.kind]
+		arg_size = actual_size(arg.ty.size)
+		full_type = f"{arg_type}{arg_size}"
+	else:
+		assert isinstance(arg.ty, type_info.PointerType) and  isinstance(arg.ty.ty, type_info.PrimitiveType)
+		arg_type = f"{instruction_utils.data_type_map[arg.ty.ty.kind]}* "
+		arg_size = actual_size(arg.ty.ty.size)
+		full_type = f"{arg_type}{arg_size}*"
+
+	return f'{full_type}{arg_name}'
 
 def generate_functions(core: arch.CoreDef, static_scalars: bool, decls_only: bool, generate_coverage: bool):
 	"""Return a generator object to generate function behavior code. Uses function

--- a/m2isar/frontends/coredsl2/architecture_model_builder.py
+++ b/m2isar/frontends/coredsl2/architecture_model_builder.py
@@ -277,7 +277,7 @@ class ArchitectureModelBuilder(CoreDSL2Visitor):
 			if ctx.decl.size:
 				size = [self.visit(obj) for obj in ctx.decl.size]
 
-		p = arch.FnParam(name, type_.size, type_.kind)
+		p = arch.FnParam(name, type_)
 		return p
 
 	def visitInteger_constant(self, ctx: CoreDSL2Parser.Integer_constantContext):

--- a/m2isar/frontends/coredsl2/parser.py
+++ b/m2isar/frontends/coredsl2/parser.py
@@ -178,10 +178,6 @@ def main():
 				raise M2SyntaxError(f"non-extern function {fn_def.name} has no body")
 
 			fn_def.ty.size = arch.get_const_or_val(fn_def.ty.size)
-			fn_def._size = fn_def.ty.size
-			for fn_arg in fn_def.args.values():
-				fn_arg._size = fn_arg.ty.size
-				fn_arg._width = fn_arg.width
 
 		logger.debug("generating function behavior")
 

--- a/m2isar/metamodel/arch.py
+++ b/m2isar/metamodel/arch.py
@@ -193,20 +193,14 @@ class RangeSpec:
 class FnParam(Named):
 	"""A function parameter."""
 
-	ty: type_info.PrimitiveType
+	ty: Union[type_info.PrimitiveType, type_info.PointerType]
 	_width: Union[int, "Parameter", "BaseNode"]
 	"""The array width of this parameter."""
 
-	def __init__(self, name, size, kind: type_info.TypeKind, width=1):
-		self.ty = type_info.PrimitiveType(kind, size)
-		self._width = width
+	def __init__(self, name, param_type : Union[type_info.PrimitiveType, type_info.PointerType]):
+		assert isinstance(param_type, (type_info.PrimitiveType, type_info.PointerType))
+		self.ty = param_type
 		super().__init__(name)
-
-	@property
-	def width(self):
-		"""Returns the resolved array width value."""
-
-		return get_const_or_val(self._width)
 
 	def __str__(self) -> str:
 		return f'{super().__str__()}, type={self.ty}'


### PR DESCRIPTION
Fixes function signatures with pointers ...
Should support this with the new typing system:
```
functions {
        extern unsigned<8> etiss_vload_encoded_unitstride(char* pV, unsigned<16> pVTYPE, unsigned<8> pVm, unsigned<16> pEEW, unsigned<8> pVd, unsigned<16> pVSTART, unsigned<16> pVLEN, unsigned<16> pVL, unsigned<64> pMSTART) [[etiss_needs_arch]];
        ...
    }
```